### PR TITLE
D8-129 Added Nimbus Sans font to d8 theme

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -17,3 +17,12 @@ a.badge,
 a.nav-link { /* Some links to not need underlines. */
   text-decoration: none;
 }
+
+body {
+  font-size: 1rem;
+  line-height: 1.5;
+  font-family: 'Nimbus Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -webkit-osx-font-smoothing: grayscale;
+  background: #f3f3f3;
+}

--- a/d8iastate.info.yml
+++ b/d8iastate.info.yml
@@ -5,6 +5,7 @@ core: 8.x
 libraries: 
   - d8iastate/global-css
   - d8iastate/global-js
+  - d8iastate/fonts
   - d8iastate/font-awesome
 stylesheets-remove:
   - core/assets/vendor/normalize-css/normalize.normalize

--- a/d8iastate.libraries.yml
+++ b/d8iastate.libraries.yml
@@ -16,6 +16,12 @@ global-js:
   dependencies: 
     - core/jquery
 
+# Nimbus Sans
+fonts:
+  css:
+    theme:
+      '//cdn.theme.iastate.edu/nimbus-sans/css/nimbus-sans.css': { type: external }
+
 # Font Awesome Icons
 font-awesome:
   remote: https://fortawesome.github.io/Font-Awesome/


### PR DESCRIPTION
Added nimbus sans font!

To test: go to a drupal 8 site on your computer using your computer's host name.
1. Type `hostname` in a command line window. You should see something like `mycomputer.ent.iastate.edu`, which is your computer's host name.
2. Go to your local drupal 8 site
3. Replace local.dev in your site's URL with your computer's host name. Your local site should go from something like: local.dev/foo
to: mycomputer.ent.iastate.edu/foo
4. Now your local site's URL should be able to grab the font from Iowa State's CDN. 😄 🎉