### PR TITLE
D8ISUTHEME-50 Fix Image Alignment radio inputs to be inline with label

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -761,6 +761,10 @@ details {
   border: 1px solid #cc0000;
 }
 
+.container-inline.form-radio {
+  display: inline-flex;
+}
+
 /* Trying to hit the main labels in some of these fields. */
 .isu-form-type_managed-file > label,
 .isu-form-type_textarea label,
@@ -775,6 +779,7 @@ details {
   color: #676767;
 }
 .isu-fieldset {
+  width: 100%;
   margin: 0.5rem 0 1rem;
   padding: 1rem;
   border-radius: 0.25rem;


### PR DESCRIPTION
![before](https://user-images.githubusercontent.com/24654361/36746788-ce1d335a-1bb8-11e8-9c59-f2cd646a6030.png)
![shouldbe](https://user-images.githubusercontent.com/24654361/36746789-ce32f5a0-1bb8-11e8-81c4-2095b5e6e5c4.png)
