### PR TITLE
D8-325 Fix ISU logo svg scaling for IE11

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -151,7 +151,7 @@
 /* Large */
 @media screen and (min-width: 992px) {
   .isu-wordmark-logo {
-    width: auto;
+    width: 100%;
     max-width: 400px;
     margin-top: 0;
   }

--- a/logo.svg
+++ b/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4800 360">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4800 360" preserveAspectRatio="xMidyMid meet" width="4800" height="360">
 	<title>Iowa State University</title>
 	<defs>
 		<style>


### PR DESCRIPTION
IE11 doesn't respect the aspect ratio of SVG that are shown via the img tag. I needed to beef up the ISU logo svg by setting height and width manually, and adding setting for aspect ratios. 

The CSS needed an adjustment as well. 

This shouldn't break things if someone subthemes with an image file.