### PR TITLE
D8ISUTHEME-56 Fix the Index alphabet dropdown background width for IE11

### DIFF
--- a/css/isu-navbar.css
+++ b/css/isu-navbar.css
@@ -109,6 +109,7 @@
 }
 .isu-navbar_alpha {
   display: flex;
+  min-width: 675px; /* Needs to be set manually for IE11 */
 }
 .isu-navbar_dropdown-menu a:hover,
 .isu-navbar_dropdown-menu a:focus,


### PR DESCRIPTION
The background of the Index alphabet dropdown was not spanning the full width of the list. IE11 requires an explicit min-width.