### PR TITLE
D8ISUTHEME-45 Add space below the site name.

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -141,7 +141,7 @@
   margin-bottom: 0.5rem;
 }
 .isu-wordmark-sitename {
-  margin-bottom: 0;
+  margin-bottom: 0.5rem;
   font-size: 1rem;
   font-weight: 500;
   line-height: 1.1;


### PR DESCRIPTION
If the logo is taller than the basic ISU wordmark, the site name was hitting the bottom edge of the read header. Added a small margin-bottom.