### PR TITLE
D8ISUTHEME-67 Remove !important for image height

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -169,7 +169,7 @@ caption {
 
 img {
   max-width: 100%;
-  height: auto !important;
+  height: auto;
 }
 table img {
   max-width: none; /* Prevents images from shrinking in tables */


### PR DESCRIPTION
img height: auto !important was catching a spacer png in the CKEditor media embed.