### PR TITLE
D8ISUTHEME-68 Add footer logo as a theme setting.

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -1,7 +1,7 @@
 isu_navbar: 1
 features:
   favicon: true
-iastate_footer_logo_path: themes/iastate_theme/isu-stacked.svg
+iastate_footer_logo_path: themes/contrib/iastate_theme/isu-stacked.svg
 iastate_contact_address: "2221 Wanda Daley Dr\n2nd Floor ASB\nAmes, IA 50011"
 iastate_contact_email: 'theme@iastate.edu'
 iastate_contact_phone: '515-294-6654'

--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -1,6 +1,7 @@
 isu_navbar: 1
 features:
   favicon: true
+iastate_footer_logo_path: themes/iastate_theme/isu-stacked.svg
 iastate_contact_address: "2221 Wanda Daley Dr\n2nd Floor ASB\nAmes, IA 50011"
 iastate_contact_email: 'theme@iastate.edu'
 iastate_contact_phone: '515-294-6654'

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -119,6 +119,8 @@ function iastate_theme_preprocess_page(&$variables) {
 
   $variables['theme_path'] = base_path() . $variables['directory'];
 
+  $variables['iastate_footer_logo_path'] = theme_get_setting('iastate_footer_logo_path');
+
   $variables['iastate_contact_title'] = theme_get_setting('iastate_contact_title');
   $variables['iastate_contact_address'] = theme_get_setting('iastate_contact_address');
   $variables['iastate_contact_email'] = theme_get_setting('iastate_contact_email');

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -23,9 +23,11 @@
           {{ page.footer_first }}
         {% endif %}
 
-        <a href="http://www.iastate.edu">
-          <img class="isu-footer-logo" src="{{theme_path}}/isu-stacked.svg" class="wordmark-isu" alt="Iowa State University">
-        </a>
+        {% if iastate_footer_logo_path %}
+          <a href="http://www.iastate.edu">
+            <img class="isu-footer-logo" src="{{ iastate_footer_logo_path }}" class="wordmark-isu" alt="Iowa State University">
+          </a>
+        {% endif %}
 
           <ul class="isu-associates-menu">
             {% if iastate_associate1_title %}

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -25,7 +25,7 @@
 
         {% if iastate_footer_logo_path %}
           <a href="http://www.iastate.edu">
-            <img class="isu-footer-logo" src="{{ iastate_footer_logo_path }}" class="wordmark-isu" alt="Iowa State University">
+            <img class="isu-footer-logo" src="{{ base_path }}/{{ iastate_footer_logo_path }}" class="wordmark-isu" alt="Iowa State University">
           </a>
         {% endif %}
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -273,4 +273,19 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
       '#title'  => t('Social 7 URL'),
       '#default_value'  => theme_get_setting('iastate_social7_url'),
     );
+
+  // Create a section for footer logo
+  $form['iastate_footer_logo'] = array(
+    '#type'         => 'details',
+    '#title'        => t('IASTATE Footer Logo'),
+    '#description'  => t('Designate a logo for the footer'),
+    '#open' => TRUE,
+  );
+
+  $form['iastate_footer_logo']['iastate_footer_logo_path'] = array(
+      '#type'   => 'textfield',
+      '#title'  => t('Path to custom footer logo'),
+      '#description' => t('Examples: logo.svg (for a file in the public filesystem), public://logo.svg, or themes/iastate_theme/logo.svg.'),
+      '#default_value'  => theme_get_setting('iastate_footer_logo_path'),
+    ); 
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -285,7 +285,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
   $form['iastate_footer_logo']['iastate_footer_logo_path'] = array(
       '#type'   => 'textfield',
       '#title'  => t('Path to custom footer logo'),
-      '#description' => t('Examples: logo.svg (for a file in the public filesystem), public://logo.svg, or themes/iastate_theme/logo.svg.'),
+      '#description' => t('Examples: logo.svg (for a file in the public filesystem), public://logo.svg, or themes/contrib/iastate_theme/logo.svg.'),
       '#default_value'  => theme_get_setting('iastate_footer_logo_path'),
     ); 
 }


### PR DESCRIPTION
This should allow site-builders to use a path for the footer logo, instead of it being hard-coded. No image upload yet.