### PR TITLE
D8ISUTHEME-70 This removes extra empty <li> from node links.

### DIFF
--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -42,15 +42,31 @@ function iastate_theme_preprocess_menu_local_action(&$variables) {
  */
 
 function iastate_theme_preprocess_links(&$variables) {
-  $variables['links']['node-readmore']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
-  $variables['links']['comment-comments']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
-  $variables['links']['comment-add']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
-  $variables['links']['comment-delete']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
-  $variables['links']['comment-edit']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
-  $variables['links']['comment-reply']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
-  /* Book */
-  $variables['links']['book_printer']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
-  $variables['links']['book_add_child']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  if (!empty($variables['links']['node-readmore']['link'])) {
+    $variables['links']['node-readmore']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  }
+  if (!empty($variables['links']['comment-comments']['link'])) {
+    $variables['links']['comment-comments']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  }
+  if (!empty($variables['links']['comment-add']['link'])) {
+    $variables['links']['comment-add']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  }
+  if (!empty($variables['links']['comment-delete']['link'])) {
+    $variables['links']['comment-delete']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
+  }
+  if (!empty($variables['links']['comment-edit']['link'])) {
+    $variables['links']['comment-edit']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
+  }
+  if (!empty($variables['links']['comment-reply']['link'])) {
+    $variables['links']['comment-reply']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary'; 
+  }
+    /* Book */ 
+  if (!empty($variables['links']['book_printer']['link'])) {
+    $variables['links']['book_printer']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  }
+  if (!empty($variables['links']['book_add_child']['link'])) {
+    $variables['links']['book_add_child']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+  }
 }
 
 /*


### PR DESCRIPTION
The preprocess function was too general and pushing classes on things that didn't exist, creating those empty <li>'s. Adding an if statement to each one seems to do the trick.

To test, a node displayed as a teaser with a Read More link should show the Read More link as a button, and there would be no extra <li> after it.