### PR TITLE
D8ISUTHEME-71 Style Edit Summary button

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -843,6 +843,44 @@ details {
 
 /* --- ## Summary --- */
 
+.field--widget-text-textarea-with-summary .field-edit-link {
+  /* Hide parentheses around 'Edit summary' button */
+  color: transparent;
+}
+
+.field--widget-text-textarea-with-summary .link-edit-summary {
+  /*
+ * Duplicates Bootstrap 4 button classes: btn btn-sm and
+ * btn-outline-secondary. Reminder that the colors for secondary
+ * button styles have been overridden in base.css. It's a bit hacky, but
+ * I can't find a good place to add the class to the template.
+ */
+  cursor: pointer;
+  /* btn */
+  display: inline-block;
+  font-weight: 400;
+  white-space: nowrap;
+  user-select: none;
+  border: 1px solid transparent;
+  transition: all 0.15s ease-in-out;
+  background-image: none;
+  /* btn-sm */
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0.2rem;
+  /* btn-outline-secondary */
+  color: #676767;
+  background-color: #ffffff;
+  border-color: #676767;
+}
+  .field--widget-text-textarea-with-summary .link-edit-summary:hover {
+    /* Modified */
+    color: #676767;
+    background-color: #efefef;
+    border-color: #676767;
+  }
+
 .text-summary-wrapper { /* class via Drupal 8 */
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
I expect the Edit Summary button on Textfields With Summaries (like most body fields) to be styled like a light outlined button without the parentheses.