### PR TITLE
D8ISUTHEME-77 Evaluating all theme templates to improve accesibility

### DIFF
--- a/templates/blocks/block--search-form-block.html.twig
+++ b/templates/blocks/block--search-form-block.html.twig
@@ -29,15 +29,22 @@
 
 {% set classes = ['isu-search'] %}
 
-<div class="isu-search_collapse" id="isu-search_collapse" aria-label="Search this website">
+{% 
+  set block_title_classes = [
+  'isu-block-title', 
+  'h4'
+  ] 
+%}
+
+<article class="isu-search_collapse" id="isu-search_collapse" aria-label="Search this website">
   <div{{ attributes.addClass(classes) }}>
     {{ title_prefix }}
     {% if label %}
-      <h2{{ title_attributes }}>{{ label }}</h2>
+      <h1{{ title_attributes.addClass(block_title_classes) }}>{{ label }}</h1>
     {% endif %}
     {{ title_suffix }}
     {% block content %}
       {{ content }}
     {% endblock %}
   </div>
-</div>
+</article>

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -33,10 +33,7 @@
   <div>
     <a class="isu-wordmark" rel="home" href="{{ path('<front>') }}" title="{{ site_name }}">
       <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
-      
-      {% set sitename_tag = is_front ? 'h1' : 'div' %}
-
-      <{{ sitename_tag }} class="isu-wordmark-sitename">{{ site_name}}</{{ sitename_tag }}>
+      <h1 class="isu-wordmark-sitename">{{ site_name}}</h1>
     </a>
   </div>
 {% endblock %}

--- a/templates/blocks/block--system-menu-block.html.twig
+++ b/templates/blocks/block--system-menu-block.html.twig
@@ -56,7 +56,7 @@
   %}
 
   {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id).addClass(block_title_classes) }}>{{ configuration.label }}</h2>
+  <h1{{ title_attributes.setAttribute('id', heading_id).addClass(block_title_classes) }}>{{ configuration.label }}</h1>
   {{ title_suffix }}
 
   {# Menu #}

--- a/templates/blocks/block.html.twig
+++ b/templates/blocks/block.html.twig
@@ -37,7 +37,7 @@
   {{ title_prefix }}
   {% if label %}
     {% set block_title_classes = ['isu-block-title', 'h4'] %}
-    <h2{{ title_attributes.addClass(block_title_classes) }}>{{ label }}</h2> 
+    <h1{{ title_attributes.addClass(block_title_classes) }}>{{ label }}</h1> 
   {% endif %}
   {{ title_suffix }}
   {% block content %}

--- a/templates/book/book-navigation.html.twig
+++ b/templates/book/book-navigation.html.twig
@@ -32,7 +32,7 @@
   <nav role="navigation" aria-labelledby="book-label-{{ book_id }}">
     {{ tree }}
     {% if has_links %}
-      <h2 id="book-label-{{ book_id}}" class="isu-book-navigation-title h5">{{ 'Navigate this book'|t }}</h2>
+      <h1 id="book-label-{{ book_id}}" class="isu-book-navigation-title h5">{{ 'Navigate this book'|t }}</h1>
       <ul class="pagination">
       {% if prev_url %}
         <li class="page-item">

--- a/templates/book/book-tree.html.twig
+++ b/templates/book/book-tree.html.twig
@@ -31,7 +31,7 @@
   {% if items %}
     {% if menu_level == 0 %}
     <nav role="navigation">
-      <h2 class="isu-book-tree-title h5">{{ 'Pages in this section'|t }}</h2>
+      <h1 class="isu-book-tree-title h5">{{ 'Pages in this section'|t }}</h1>
       <ul{{ attributes }}>
     {% else %}
       <ul>

--- a/templates/components/status-messages.html.twig
+++ b/templates/components/status-messages.html.twig
@@ -35,7 +35,7 @@
     ] 
   %}
 
-  <div role="contentinfo" aria-label="{{ status_headings[type] }}"{{ attributes|without('role', 'aria-label').addClass(alert_front_classes) }}>
+  <div role="alert" aria-label="{{ status_headings[type] }}"{{ attributes|without('role', 'aria-label').addClass(alert_front_classes) }}>
 
     {% if type == 'status' %}
       <div role="alert" class="alert alert-success">

--- a/templates/content/comment.html.twig
+++ b/templates/content/comment.html.twig
@@ -76,7 +76,7 @@
         <div>
           {% if title %}
             {{ title_prefix }}
-            <h3{{ title_attributes }} class="isu-comment_title">{{title}}</h3>
+            <h1{{ title_attributes }} class="isu-comment_title">{{title}}</h1>
             {{ title_suffix }}
           {% endif %}
           <span class="isu-comment_submitted">{{ submitted }}</span>

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -85,14 +85,15 @@
 
   {{ title_prefix }}
   {% if not page %}
-    <h2{{ title_attributes }}>
+    <h1{{ title_attributes }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-    </h2>
+    </h1>
   {% endif %}
   {{ title_suffix }}
 
   {% if display_submitted %}
     {% include '@iastate_theme/parts/submitted-by.html.twig' %}
+    {# Comes in as footer element #}
   {% endif %}
 
   <div{{ content_attributes }}>

--- a/templates/fields/field--comment.html.twig
+++ b/templates/fields/field--comment.html.twig
@@ -37,14 +37,14 @@
 <section{{ attributes.addClass('isu-comments-section') }} aria-label="Comments">
   {% if comments and not label_hidden %}
     {{ title_prefix }}
-    <h2{{ title_attributes.addClass(comments_title_classes) }}>{{ label }}</h2>
+    <h1{{ title_attributes.addClass(comments_title_classes) }}>{{ label }}</h1>
     {{ title_suffix }}
   {% endif %}
 
   {{ comments }}
 
   {% if comment_form %}
-    <h2{{ content_attributes.addClass(comments_title_classes) }}>{{ 'Add new comment'|t }}</h2>
+    <h1{{ content_attributes.addClass(comments_title_classes) }}>{{ 'Add new comment'|t }}</h1>
     {{ comment_form }}
   {% endif %}
 

--- a/templates/fields/field--node--body.html.twig
+++ b/templates/fields/field--node--body.html.twig
@@ -60,7 +60,16 @@
   {% endif %}
 {% else %}
   <div{{ attributes }}>
-    <div{{ title_attributes }}>{{ label }}</div>
+      
+    {% 
+      set label_classes = [
+        label_display == 'inline' ? 'd-inline-block',
+        label_display == 'visually_hidden' ? 'sr-only',
+        'font-weight-bold',
+      ]
+    %}
+
+    <div{{ title_attributes.addClass(label_classes) }}>{{ label }}</div>
     {% if multiple %}
       <div>
     {% endif %}

--- a/templates/forums/node--forum.html.twig
+++ b/templates/forums/node--forum.html.twig
@@ -74,14 +74,15 @@
 
   {{ title_prefix }}
   {% if not page %}
-    <h2{{ title_attributes }}>
+    <h1{{ title_attributes }}>
       <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-    </h2>
+    </h1>
   {% endif %}
   {{ title_suffix }}
 
   {% if display_submitted %}
     {% include '@iastate_theme/parts/submitted-by.html.twig' %}
+    {# Comes in as footer element #}
   {% endif %}
 
   <div{{ content_attributes.addClass('isu-forum-post') }}>

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -8,8 +8,7 @@
  */
 #}
 {% if breadcrumb %}
-  <nav role="navigation" aria-labelledby="system-breadcrumb">
-    <h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>
+  <nav role="navigation" aria-label="{{ 'Breadcrumb'|t }}">
     <ol class="breadcrumb isu-breadcrumb">
     {% for item in breadcrumb %}
       <li class="breadcrumb-item">

--- a/templates/navigation/links.html.twig
+++ b/templates/navigation/links.html.twig
@@ -32,35 +32,38 @@
  */
 #}
 
+{% set heading_id = attributes.id ~ '-toolbar'|clean_id %}
+
 {% if links -%}
-  {%- if heading -%}
-    {%- if heading.level -%}
-      <{{ heading.level }}{{ heading.attributes }}>{{ heading.text }}</{{ heading.level }}>
-    {%- else -%}
-      <h2{{ heading.attributes }}>{{ heading.text }}</h2>
+  <div role="toolbar" aria-labelledby="{{heading_id}}">
+    {%- if heading -%}
+      {%- if heading.level -%}
+        <{{ heading.level }}{{ heading.attributes.setAttribute('id', heading_id) }}>{{ heading.text }}</{{ heading.level }}>
+      {%- else -%}
+        <div{{ heading.attributes.setAttribute('id', heading_id) }}>{{ heading.text }}</div>
+      {%- endif -%}
     {%- endif -%}
-  {%- endif -%}
 
+    {% 
+      set list_classes = [
+        'list-inline',
+        'isu-links'
+      ] 
+    %}
 
-  {% 
-    set list_classes = [
-      'list-inline',
-      'isu-links'
-    ] 
-  %}
+    <ul{{ attributes.addClass(list_classes) }}>
+      {%- for item in links -%}
+        <li{{ item.attributes.addClass('list-inline-item') }}>
+          {%- if item.link and item.text -%}
+            {{ item.link }}
 
-  <ul{{ attributes.addClass(list_classes) }}>
-    {%- for item in links -%}
-      <li{{ item.attributes.addClass('list-inline-item') }}>
-        {%- if item.link and item.text -%}
-          {{ item.link }}
-
-        {%- elseif item.text_attributes -%}
-          <span{{ item.text_attributes }}>{{ item.text }}</span>
-        {%- else -%}
-          {{ item.text }}
-        {%- endif -%}
-      </li>
-    {%- endfor -%}
-  </ul>
+          {%- elseif item.text_attributes -%}
+            <span{{ item.text_attributes }}>{{ item.text }}</span>
+          {%- else -%}
+            {{ item.text }}
+          {%- endif -%}
+        </li>
+      {%- endfor -%}
+    </ul>
+  </div>
 {%- endif %}

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -13,10 +13,8 @@
 #}
 
 {% if primary %}
-  <h2 class="visually-hidden">{{ 'Primary tabs'|t }}</h2>
-  <ul class="nav nav-tabs mb-3">{{ primary }}</ul>
+  <ul class="nav nav-tabs mb-3" role="toolbar" aria-label="{{ 'Primary tabs'|t }}">{{ primary }}</ul>
 {% endif %}
 {% if secondary %}
-  <h2 class="visually-hidden">{{ 'Secondary tabs'|t }}</h2>
-  <ul class="nav nav-tabs isu-nav-tabs_sm mb-3">{{ secondary }}</ul>
+  <ul class="nav nav-tabs isu-nav-tabs_sm mb-3" role="toolbar" aria-label="{{ 'Secondary tabs'|t }}">{{ secondary }}</ul>
 {% endif %}

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -33,27 +33,29 @@
           {% endif %}
         {% endif %}
 
-        <h2 class="visually-hidden" id="footerassociatesmenu">Associates</h2>
-        <ul class="isu-associates-menu">
-          {% if iastate_associate1_title %}
-            <li><a href="{{ iastate_associate1_url }}">{{ iastate_associate1_title }}</a></li>
-          {% endif %}
-          {% if iastate_associate2_title %}
-            <li><a href="{{ iastate_associate2_url }}">{{ iastate_associate2_title }}</a></li>
-          {% endif %}
-          {% if iastate_associate3_title %}
-            <li><a href="{{ iastate_associate3_url }}">{{ iastate_associate3_title }}</a></li>
-          {% endif %}
-          {% if iastate_associate4_title %}
-            <li><a href="{{ iastate_associate4_url }}">{{ iastate_associate4_title }}</a></li>
-          {% endif %}
-          {% if iastate_associate5_title %}
-            <li><a href="{{ iastate_associate5_url }}">{{ iastate_associate5_title }}</a></li>
-          {% endif %}
-          {% if iastate_associate6_title %}
-            <li><a href="{{ iastate_associate6_url }}">{{ iastate_associate6_title }}</a></li>
-          {% endif %}
-        </ul>
+        {% if iastate_associate1_title or iastate_associate1_url %}
+          <h2 class="visually-hidden" id="footerassociatesmenu">Associates</h2>
+          <ul class="isu-associates-menu">
+            {% if iastate_associate1_title %}
+              <li><a href="{{ iastate_associate1_url }}">{{ iastate_associate1_title }}</a></li>
+            {% endif %}
+            {% if iastate_associate2_title %}
+              <li><a href="{{ iastate_associate2_url }}">{{ iastate_associate2_title }}</a></li>
+            {% endif %}
+            {% if iastate_associate3_title %}
+              <li><a href="{{ iastate_associate3_url }}">{{ iastate_associate3_title }}</a></li>
+            {% endif %}
+            {% if iastate_associate4_title %}
+              <li><a href="{{ iastate_associate4_url }}">{{ iastate_associate4_title }}</a></li>
+            {% endif %}
+            {% if iastate_associate5_title %}
+              <li><a href="{{ iastate_associate5_url }}">{{ iastate_associate5_title }}</a></li>
+            {% endif %}
+            {% if iastate_associate6_title %}
+              <li><a href="{{ iastate_associate6_url }}">{{ iastate_associate6_title }}</a></li>
+            {% endif %}
+          </ul>
+        {% endif %}
 
       </div>
 
@@ -63,35 +65,44 @@
           {{ page.footer_second }}
         {% endif %}
 
-        {% if iastate_contact_title %}
-          <h2 class="isu-footer_contact-title h5" id="footercontact">
-            {{ iastate_contact_title|nl2br }}
-          </h2>
-        {% else %}
-          <h2 class="visually-hidden" id="footercontact">Contact</h2>
-        {% endif %}
-        {% if iastate_contact_address %}
-          <div class="isu-footer_contact-address">
-            {{ iastate_contact_address|nl2br }}
-          </div>
-        {% endif %}
+        {% if
+          iastate_contact_title or 
+          iastate_contact_address or 
+          iastate_contact_email or 
+          iastate_contact_phone or 
+          iastate_contact_phone 
+        %}
 
-        {% if iastate_contact_email %}
-          <div class="isu-footer_contact-email">
-            <a href="mailto:{{ iastate_contact_email }}">{{ iastate_contact_email }}</a>
-          </div>
-        {% endif %}
+          {% if iastate_contact_title %}
+            <h2 class="isu-footer_contact-title h5" id="footercontact">
+              {{ iastate_contact_title|nl2br }}
+            </h2>
+          {% else %}
+            <h2 class="visually-hidden" id="footercontact">Contact</h2>
+          {% endif %}
+          {% if iastate_contact_address %}
+            <div class="isu-footer_contact-address">
+              {{ iastate_contact_address|nl2br }}
+            </div>
+          {% endif %}
 
-        {% if iastate_contact_phone %}
-          <div class="isu-footer_contact-phone">
-            <span>phone: {{ iastate_contact_phone }}</span>
-          </div>
-        {% endif %}
+          {% if iastate_contact_email %}
+            <div class="isu-footer_contact-email">
+              <a href="mailto:{{ iastate_contact_email }}">{{ iastate_contact_email }}</a>
+            </div>
+          {% endif %}
 
-        {% if iastate_contact_fax %}
-          <div class="isu-footer_contact-fax">
-            <span>fax: {{ iastate_contact_fax }}</span>
-          </div>
+          {% if iastate_contact_phone %}
+            <div class="isu-footer_contact-phone">
+              <span>Phone: {{ iastate_contact_phone }}</span>
+            </div>
+          {% endif %}
+
+          {% if iastate_contact_fax %}
+            <div class="isu-footer_contact-fax">
+              <span>Fax: {{ iastate_contact_fax }}</span>
+            </div>
+          {% endif %}
         {% endif %}
 
       </div>
@@ -102,30 +113,33 @@
           {{ page.footer_third }}
         {% endif %}
 
-        <h2 class="visually-hidden" id="footersocialmenu">Social media</h2>
-        <ul class="isu-social-menu">
-          {% if iastate_social1_title %}
-            <li><a href="{{ iastate_social1_url }}">{{ iastate_social1_title }}</a></li>
-          {% endif %}
-          {% if iastate_social2_title %}
-            <li><a href="{{ iastate_social2_url }}">{{ iastate_social2_title }}</a></li>
-          {% endif %}
-          {% if iastate_social3_title %}
-            <li><a href="{{ iastate_social3_url }}">{{ iastate_social3_title }}</a></li>
-          {% endif %}
-          {% if iastate_social4_title %}
-            <li><a href="{{ iastate_social4_url }}">{{ iastate_social4_title }}</a></li>
-          {% endif %}
-          {% if iastate_social5_title %}
-            <li><a href="{{ iastate_social5_url }}">{{ iastate_social5_title }}</a></li>
-          {% endif %}
-          {% if iastate_social6_title %}
-            <li><a href="{{ iastate_social6_url }}">{{ iastate_social6_title }}</a></li>
-          {% endif %}
-          {% if iastate_social7_title %}
-            <li><a href="{{ iastate_social7_url }}">{{ iastate_social7_title }}</a></li>
-          {% endif %}
-        </ul>
+        {% if iastate_social1_title or iastate_social1_url %}
+
+          <h2 class="visually-hidden" id="footersocialmenu">Social media</h2>
+          <ul class="isu-social-menu">
+            {% if iastate_social1_title %}
+              <li><a href="{{ iastate_social1_url }}">{{ iastate_social1_title }}</a></li>
+            {% endif %}
+            {% if iastate_social2_title %}
+              <li><a href="{{ iastate_social2_url }}">{{ iastate_social2_title }}</a></li>
+            {% endif %}
+            {% if iastate_social3_title %}
+              <li><a href="{{ iastate_social3_url }}">{{ iastate_social3_title }}</a></li>
+            {% endif %}
+            {% if iastate_social4_title %}
+              <li><a href="{{ iastate_social4_url }}">{{ iastate_social4_title }}</a></li>
+            {% endif %}
+            {% if iastate_social5_title %}
+              <li><a href="{{ iastate_social5_url }}">{{ iastate_social5_title }}</a></li>
+            {% endif %}
+            {% if iastate_social6_title %}
+              <li><a href="{{ iastate_social6_url }}">{{ iastate_social6_title }}</a></li>
+            {% endif %}
+            {% if iastate_social7_title %}
+              <li><a href="{{ iastate_social7_url }}">{{ iastate_social7_title }}</a></li>
+            {% endif %}
+          </ul>
+        {% endif %}
       </div>
 
       <div class="col-sm-6 col-md-6 col-lg-3">

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -33,26 +33,27 @@
           {% endif %}
         {% endif %}
 
-          <ul class="isu-associates-menu">
-            {% if iastate_associate1_title %}
-              <li><a href="{{ iastate_associate1_url }}">{{ iastate_associate1_title }}</a></li>
-            {% endif %}
-            {% if iastate_associate2_title %}
-              <li><a href="{{ iastate_associate2_url }}">{{ iastate_associate2_title }}</a></li>
-            {% endif %}
-            {% if iastate_associate3_title %}
-              <li><a href="{{ iastate_associate3_url }}">{{ iastate_associate3_title }}</a></li>
-            {% endif %}
-            {% if iastate_associate4_title %}
-              <li><a href="{{ iastate_associate4_url }}">{{ iastate_associate4_title }}</a></li>
-            {% endif %}
-            {% if iastate_associate5_title %}
-              <li><a href="{{ iastate_associate5_url }}">{{ iastate_associate5_title }}</a></li>
-            {% endif %}
-            {% if iastate_associate6_title %}
-              <li><a href="{{ iastate_associate6_url }}">{{ iastate_associate6_title }}</a></li>
-            {% endif %}
-          </ul>
+        <h2 class="visually-hidden" id="footerassociatesmenu">Associates</h2>
+        <ul class="isu-associates-menu">
+          {% if iastate_associate1_title %}
+            <li><a href="{{ iastate_associate1_url }}">{{ iastate_associate1_title }}</a></li>
+          {% endif %}
+          {% if iastate_associate2_title %}
+            <li><a href="{{ iastate_associate2_url }}">{{ iastate_associate2_title }}</a></li>
+          {% endif %}
+          {% if iastate_associate3_title %}
+            <li><a href="{{ iastate_associate3_url }}">{{ iastate_associate3_title }}</a></li>
+          {% endif %}
+          {% if iastate_associate4_title %}
+            <li><a href="{{ iastate_associate4_url }}">{{ iastate_associate4_title }}</a></li>
+          {% endif %}
+          {% if iastate_associate5_title %}
+            <li><a href="{{ iastate_associate5_url }}">{{ iastate_associate5_title }}</a></li>
+          {% endif %}
+          {% if iastate_associate6_title %}
+            <li><a href="{{ iastate_associate6_url }}">{{ iastate_associate6_title }}</a></li>
+          {% endif %}
+        </ul>
 
       </div>
 
@@ -63,9 +64,11 @@
         {% endif %}
 
         {% if iastate_contact_title %}
-          <h2 class="isu-footer_contact-title h5">
+          <h2 class="isu-footer_contact-title h5" id="footercontact">
             {{ iastate_contact_title|nl2br }}
           </h2>
+        {% else %}
+          <h2 class="visually-hidden" id="footercontact">Contact</h2>
         {% endif %}
         {% if iastate_contact_address %}
           <div class="isu-footer_contact-address">
@@ -99,30 +102,30 @@
           {{ page.footer_third }}
         {% endif %}
 
-          <ul class="isu-social-menu">
-            {% if iastate_social1_title %}
-              <li><a href="{{ iastate_social1_url }}">{{ iastate_social1_title }}</a></li>
-            {% endif %}
-            {% if iastate_social2_title %}
-              <li><a href="{{ iastate_social2_url }}">{{ iastate_social2_title }}</a></li>
-            {% endif %}
-            {% if iastate_social3_title %}
-              <li><a href="{{ iastate_social3_url }}">{{ iastate_social3_title }}</a></li>
-            {% endif %}
-            {% if iastate_social4_title %}
-              <li><a href="{{ iastate_social4_url }}">{{ iastate_social4_title }}</a></li>
-            {% endif %}
-            {% if iastate_social5_title %}
-              <li><a href="{{ iastate_social5_url }}">{{ iastate_social5_title }}</a></li>
-            {% endif %}
-            {% if iastate_social6_title %}
-              <li><a href="{{ iastate_social6_url }}">{{ iastate_social6_title }}</a></li>
-            {% endif %}
-            {% if iastate_social7_title %}
-              <li><a href="{{ iastate_social7_url }}">{{ iastate_social7_title }}</a></li>
-            {% endif %}
-          </ul>
-
+        <h2 class="visually-hidden" id="footersocialmenu">Social media</h2>
+        <ul class="isu-social-menu">
+          {% if iastate_social1_title %}
+            <li><a href="{{ iastate_social1_url }}">{{ iastate_social1_title }}</a></li>
+          {% endif %}
+          {% if iastate_social2_title %}
+            <li><a href="{{ iastate_social2_url }}">{{ iastate_social2_title }}</a></li>
+          {% endif %}
+          {% if iastate_social3_title %}
+            <li><a href="{{ iastate_social3_url }}">{{ iastate_social3_title }}</a></li>
+          {% endif %}
+          {% if iastate_social4_title %}
+            <li><a href="{{ iastate_social4_url }}">{{ iastate_social4_title }}</a></li>
+          {% endif %}
+          {% if iastate_social5_title %}
+            <li><a href="{{ iastate_social5_url }}">{{ iastate_social5_title }}</a></li>
+          {% endif %}
+          {% if iastate_social6_title %}
+            <li><a href="{{ iastate_social6_url }}">{{ iastate_social6_title }}</a></li>
+          {% endif %}
+          {% if iastate_social7_title %}
+            <li><a href="{{ iastate_social7_url }}">{{ iastate_social7_title }}</a></li>
+          {% endif %}
+        </ul>
       </div>
 
       <div class="col-sm-6 col-md-6 col-lg-3">
@@ -131,7 +134,11 @@
           {{ page.footer_fourth }}
         {% endif %}
 
+        <h2 class="visually-hidden">Copyright Information</h2>
+
         <p class="isu-copyright">Copyright © 1995-<script>document.write(new Date().getFullYear())</script><br>Iowa State University<br>of Science and Technology<br>All rights reserved.</p>
+
+        <h2 class="visually-hidden">Legal and Privay Links</h2>
         <ul class="isu-legal-menu">
           <li><a href="http://www.policy.iastate.edu/policy/discrimination">Non-discrimination Policy</a></li>
           <li><a href="http://www.policy.iastate.edu/electronicprivacy">Privacy Policy</a></li>

--- a/templates/parts/menu-navbar.html.twig
+++ b/templates/parts/menu-navbar.html.twig
@@ -12,7 +12,7 @@
  */
 #}
 
-<div>
+<div> <!-- This class-less div is required so the layout won't collapse. -->
   <div class="navbar navbar-expand-lg isu-menu-navbar">
     <div class="container isu-menu-navbar_container">
        <div class="isu-menu-navbar_collapse isu-menu-navbar_wrap" id="isu-menu-navbar_collapse">

--- a/templates/parts/submitted-by.html.twig
+++ b/templates/parts/submitted-by.html.twig
@@ -6,7 +6,7 @@
  */
 #}
 
-<footer class="isu-submitted-by_card d-flex align-items-center mb-3" aria-label="Author">
+<footer class="isu-submitted-by_card d-flex align-items-center mb-3" role="contentinfo">
   {{ author_picture }}
   <div>
     <span class="isu-submitted-by_name">{% trans %}Submitted by {{ author_name }} </span>

--- a/templates/search/item-list--search-results.html.twig
+++ b/templates/search/item-list--search-results.html.twig
@@ -32,11 +32,13 @@
 
     <{{ list_type }}{{ attributes }}>
       {%- for item in items -%}
-        {% set search_item_classes = ['isu-search-item', 'card', 'mb-3'] %}
+        {% set search_item_classes = ['isu-search-item', 'mb-3'] %}
         <li{{ item.attributes.addClass(search_item_classes) }}>
-          <div class="card-body">
-            {{ item.value }}
-          </div>
+          <article class="card">
+            <div class="card-body">
+              {{ item.value }}
+            </div>
+          </article>
         </li>
       {%- endfor -%}
     </{{ list_type }}>

--- a/templates/search/search-result.html.twig
+++ b/templates/search/search-result.html.twig
@@ -57,9 +57,9 @@
  */
 #}
 {{ title_prefix }}
-<h3{{ title_attributes.addClass('h5') }}>
+<h1{{ title_attributes.addClass('h5') }}>
   <a href="{{ url }}">{{ title }}</a>
-</h3>
+</h1>
 {{ title_suffix }}
 
 {% if info %}


### PR DESCRIPTION
Big pull request. I went through all the base theme templates to see where we could improve the HTML/ARIA semantic elements. In many cases, I've switched to the strategy of wrapping self-contained content in `article` elements and starting any headings over at `h1`. More information about that:

- https://keithjgrant.com/posts/2018/03/html5-sectioning-and-landmark-elements/
- https://www.w3.org/WAI/GL/wiki/Using_HTML5_article_element
- https://www.w3.org/TR/2011/WD-html5-author-20110705/headings-and-sections.html#headings-and-sections
- https://www.w3.org/TR/2011/WD-html5-author-20110705/content-models.html#sectioning-content

Because CSS is not coupled to elements, there should be no visual changes.