### PR TITLE
D8ISUTHEME-81 Fixed all the extra space around the header search bar

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -137,7 +137,9 @@ body,
     text-align: left;
   }
   .isu-region_header-second {
-    padding: 0;
+    display: flex;
+    flex-direction: column;
+    padding-top: 0.5rem;
   }
   .isu-col-header-second {
     padding: 0 15px; /* Back to Bootstrap 4 default */
@@ -213,17 +215,6 @@ body,
   border-radius: 0 0.25rem 0.25rem 0;
 }
 
-/* Large */
-@media screen and (min-width: 992px) {
-  .isu-search {
-    margin-top: 0;
-  }
-  .isu-region_header-second .isu-search__search-field.form-control {
-    /* .form-control via Bootstrap 4 */
-    width: 400px;
-  }
-}
-
 /* Specific to Site Navbar search */
 
 .isu-search {
@@ -233,8 +224,12 @@ body,
 /* Large */
 @media screen and (min-width: 992px) {
   .isu-search {
-    margin-top: 1rem;
+    margin-top: 0;
     padding: 0;
+  }
+  .isu-region_header-second .isu-search__search-field.form-control {
+    /* .form-control via Bootstrap 4 */
+    width: 400px;
   }
 }
 
@@ -562,7 +557,7 @@ body,
  * The most basic unit of content which appears all over.
  */
 
-article:not(.isu-user) {
+article:not(.isu-user):not(.isu-search_collapse) {
   margin-bottom: 2rem;
 }
 .isu-node-title {


### PR DESCRIPTION
Right now the alignment of items in the second Header region is handled with margins and padding, but this sometimes creates extra gaps. Handling it with flexbox should make the space more flexible. 

To test: 
1. Make sure the search box is in Header Second. Does it look okay? Is it vertically centered?
2. Add the Site Links menu below it. (https://github.com/isubit/iastate_theme/wiki/Site-Navbar) How is the spacing now? Is it also nicely vertically centered without big gaps?