### PR TITLE
D8-705 Add support for the site slogan

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -170,18 +170,24 @@ body,
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
-.isu-wordmark-slogan {
-  margin-bottom: 0.5rem;
-  padding-bottom: 0.5rem;
-  font-weight: bold;
-  border-bottom: 1px solid rgba(255,255,255,0.5);
-}
+.isu-wordmark-slogan,
 .isu-wordmark-sitename {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
+  font-weight: bold;
+  font-size: 1rem;
+}
+/* If there is both a slogan and site name,
+ * site name gets slogan's styling and then 
+ * a border.
+ */
+.isu-wordmark-sitename_slogan {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
   font-size: 1rem;
   font-weight: 500;
   line-height: 1.1;
   color: #ffffff;
+  border-top: 1px solid rgba(255, 255, 255, 0.5);
 }
 
 /* Large */
@@ -191,7 +197,7 @@ body,
     max-width: 400px;
     margin-top: 0;
   }
-  .isu-wordmark-sitename {
+  .isu-wordmark-sitename_slogan {
     font-size: 1.15rem;
   }
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -170,6 +170,12 @@ body,
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
+.isu-wordmark-slogan {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-weight: bold;
+  border-bottom: 1px solid rgba(255,255,255,0.5);
+}
 .isu-wordmark-sitename {
   margin-bottom: 0.5rem;
   font-size: 1rem;

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -33,6 +33,7 @@
   <div>
     <a class="isu-wordmark" rel="home" href="{{ path('<front>') }}" title="{{ site_name }}">
       <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
+      <div class="isu-wordmark-slogan">{{ site_slogan }}</div>
       <h1 class="isu-wordmark-sitename">{{ site_name}}</h1>
     </a>
   </div>

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -33,8 +33,12 @@
   <div>
     <a class="isu-wordmark" rel="home" href="{{ path('<front>') }}" title="{{ site_name }}">
       <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
-      <div class="isu-wordmark-slogan">{{ site_slogan }}</div>
-      <h1 class="isu-wordmark-sitename">{{ site_name}}</h1>
+      {% if site_slogan %}
+        <div class="isu-wordmark-slogan">{{ site_slogan }}</div>
+        <h1 class="isu-wordmark-sitename_slogan">{{ site_name}}</h1>
+      {% else %}
+        <h1 class="isu-wordmark-sitename">{{ site_name}}</h1>
+      {% endif %}
     </a>
   </div>
 {% endblock %}


### PR DESCRIPTION
To test:

* Create a Drupal 8 site with this branch of the base theme
* The site name should now be smaller. 
* Fill in a site slogan. The site slogan should be small, and the site name large, and a line should separate.

This is the help more closely conform to ISU marketing standards which has clear requirements about what text can be part of an ISU wordmark.