### PR TITLE
D8-710 Changes to button colors

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -106,6 +106,15 @@ button.btn {
     background-color: #1A6B2D;
     border-color: #1A6B2D;
   }
+.btn-outline-info { /* Overrides bootstrap.min.css */
+  color: #128091; /* Sufficient contrast with white. */
+  background-color: #ffffff;
+  border-color: #128091;
+}
+  .btn-outline-info:hover {
+    background-color: #0F6875;
+    border-color: #0F6875;
+  }
 .btn-outline-warning {
   color: #757575; /* Sufficient contrast with white. */
 }

--- a/css/base.css
+++ b/css/base.css
@@ -67,47 +67,66 @@ button.btn {
 .btn-link:hover { /* Overrides bootstrap.min.css */
   color: #006BA6; /* ISU brand standard */
 }
-.btn-primary { /* Overrides bootstrap.min.css */
-  background-color: #cc0000; /* ISU brand standard */
-  border-color: #cc0000;
+.btn-success { /* Overrides bootstrap.min.css */
+  background-color: #218739; /* Sufficient contrast with white. */
+  border-color: #218739;
 }
-  .btn-primary:hover {
-    background-color: #a00606;
-    border-color: #a00606;
+  .btn-success:hover {
+    background-color: #1A6B2D;
+    border-color: #1A6B2D;
   }
-.btn-outline-primary { /* Overrides bootstrap.min.css */
-  color: #cc0000; /* ISU brand standard */
+.btn-info { /* Overrides bootstrap.min.css */
+  background-color: #128091; /* Sufficient contrast with white. */
+  border-color: #128091;
+}
+  .btn-info:hover {
+    background-color: #0F6875;
+    border-color: #0F6875;
+  }
+.btn-light {
+  border-color: #ddd;
+}
+.btn-outline-primary,
+.btn-outline-secondary,
+.btn-outline-success,
+.btn-outline-danger,
+.btn-outline-warning,
+.btn-outline-info,
+.btn-outline-light,
+.btn-outline-dark { /* Overrides bootstrap.min.css */
   background-color: #ffffff;
-  border-color: #cc0000;
 }
-  .btn-outline-primary:hover {
-    background-color: #a00606;
-    border-color: #a00606;
-  }
-.btn-secondary { /* Overrides bootstrap.min.css */
-  background-color: #676767; /* ISU brand standard */
-  border-color: #676767;
-}
-  .btn-secondary:hover {
-    color: #ffffff;
-    background-color: #575757;
-    border-color: #575757;
-  }
-.btn-outline-secondary { /* Overrides bootstrap.min.css */
-  color: #676767; /* Sufficient contrast with white. */
+
+.btn-outline-success { /* Overrides bootstrap.min.css */
+  color: #218739; /* Sufficient contrast with white. */
   background-color: #ffffff;
-  border-color: #676767;
+  border-color: #218739;
 }
-  .btn-outline-secondary:hover {
-    color: #ffffff;
-    background-color: #575757;
-    border-color: #575757;
+  .btn-outline-success:hover {
+    background-color: #1A6B2D;
+    border-color: #1A6B2D;
   }
-.btn-primary.disabled,
-.btn-primary:disabled { /* Overrides bootstrap.min.css */
-  background-color: #cc0000; /* ISU brand standard */
-  border-color: #cc0000;
+.btn-outline-warning {
+  color: #757575; /* Sufficient contrast with white. */
 }
+.btn-outline-light { /* Overrides bootstrap.min.css */
+  color: #757575; /* Sufficient contrast with white. */
+  background-color: #ffffff;
+  border-color: #888888;
+}
+  .btn-outline-light:hover {
+    border-color: #c2c2c2;
+  }
+
+.btn.disabled, 
+.btn:disabled { /* Overrides bootstrap.min.css */
+  /* Sufficient contrast with white. */
+  opacity: 1;
+  background: #e6e6e6;
+  color: #676767;
+  border: 1px solid #bbb;
+}
+
 .button:not(.btn) { /* Duplicates Bootstrap 4 btn, btn-secondary and btn-sm */
   /* btn */
   display: inline-block;

--- a/css/theme.css
+++ b/css/theme.css
@@ -876,15 +876,14 @@ details {
   line-height: 1.5;
   border-radius: 0.2rem;
   /* btn-outline-secondary */
-  color: #676767;
+  color: #6c757d;
   background-color: #ffffff;
-  border-color: #676767;
+  border-color: #6c757d;
 }
   .field--widget-text-textarea-with-summary .link-edit-summary:hover {
-    /* Modified */
-    color: #676767;
-    background-color: #efefef;
-    border-color: #676767;
+    color: #ffffff;
+    background-color: #6c757d;
+    border-color: #6c757d;
   }
 
 .text-summary-wrapper { /* class via Drupal 8 */
@@ -983,16 +982,16 @@ details {
   line-height: 1.5;
   border-radius: .25rem;
   transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
-  /* btn-outline-secondary */
-  color: #676767;
+  /* btn-outline-danger */
+  color: #dc3545;
   background-color: #ffffff;
-  border-color: #676767;
+  border-color: #dc3545;
 }
 
 #edit-delete:hover {
   color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d;
+  background-color: #dc3545;
+  border-color: #dc3545;
 }
 
 #edit-delete:focus {
@@ -1067,16 +1066,16 @@ a.tabledrag-handle .handle {
   line-height: 1.5;
   border-radius: 0.2rem;
   /* btn-outline-secondary */
-  color: #676767;
+  color: #6c757d;
   background-color: #ffffff;
-  border-color: #676767;
+  border-color: #6c757d;
   /* Modification */
   margin-bottom: 0.5rem;
 }
   .tabledrag-toggle-weight:hover {
     color: #ffffff;
-    background-color: #575757;
-    border-color: #575757;
+    background-color: #6c757d;
+    border-color: #6c757d;
   }
 
 /* --- ## Vertical Tabs --- */

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -20,7 +20,7 @@ function iastate_theme_preprocess_menu_local_task(&$variables) {
  */
 
 function iastate_theme_preprocess_views_view(&$variables) {
-  $variables['more']['#options']['attributes']['class'] = array('btn', 'btn-sm', 'btn-outline-primary');
+  $variables['more']['#options']['attributes']['class'] = array('btn', 'btn-sm', 'btn-outline-danger');
 }
 
 /*
@@ -32,7 +32,7 @@ function iastate_theme_preprocess_views_view(&$variables) {
 function iastate_theme_preprocess_menu_local_action(&$variables) {
   $variables['link']['#options']['attributes']['class'][] = 'btn';
   $variables['link']['#options']['attributes']['class'][] = 'btn-sm';
-  $variables['link']['#options']['attributes']['class'][] = 'btn-outline-primary';
+  $variables['link']['#options']['attributes']['class'][] = 'btn-outline-info';
 }
 
 /*
@@ -43,29 +43,29 @@ function iastate_theme_preprocess_menu_local_action(&$variables) {
 
 function iastate_theme_preprocess_links(&$variables) {
   if (!empty($variables['links']['node-readmore']['link'])) {
-    $variables['links']['node-readmore']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+    $variables['links']['node-readmore']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-danger';
   }
   if (!empty($variables['links']['comment-comments']['link'])) {
-    $variables['links']['comment-comments']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+    $variables['links']['comment-comments']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-danger';
   }
   if (!empty($variables['links']['comment-add']['link'])) {
-    $variables['links']['comment-add']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+    $variables['links']['comment-add']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-success';
   }
   if (!empty($variables['links']['comment-delete']['link'])) {
-    $variables['links']['comment-delete']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
+    $variables['links']['comment-delete']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-danger';
   }
   if (!empty($variables['links']['comment-edit']['link'])) {
-    $variables['links']['comment-edit']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-secondary';
+    $variables['links']['comment-edit']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-info';
   }
   if (!empty($variables['links']['comment-reply']['link'])) {
-    $variables['links']['comment-reply']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary'; 
+    $variables['links']['comment-reply']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-success'; 
   }
     /* Book */ 
   if (!empty($variables['links']['book_printer']['link'])) {
-    $variables['links']['book_printer']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+    $variables['links']['book_printer']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-info';
   }
   if (!empty($variables['links']['book_add_child']['link'])) {
-    $variables['links']['book_add_child']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-primary';
+    $variables['links']['book_add_child']['link']['#options']['attributes']['class'][] = 'btn btn-sm btn-outline-success';
   }
 }
 

--- a/templates/components/views-view-summary-unformatted.html.twig
+++ b/templates/components/views-view-summary-unformatted.html.twig
@@ -29,7 +29,7 @@
       row.active ? 'active',
       'btn',
       'btn-sm',
-      'btn-outline-primary',
+      'btn-outline-info',
       'isu-unformatted-summary_row'
     ] 
   %}

--- a/templates/forms/input--submit.html.twig
+++ b/templates/forms/input--submit.html.twig
@@ -25,7 +25,7 @@
     set submit_classes = [
       'btn', 
       'btn-sm', 
-      'btn-outline-secondary',  
+      'btn-outline-success',  
       'isu-add-another-item-button', 
       'isu-form-submit'
       ] 
@@ -39,7 +39,7 @@
     set submit_classes = [
       'btn', 
       'btn-sm', 
-      'btn-outline-secondary', 
+      'btn-outline-danger', 
       'isu-remove-button', 
       'isu-form-submit'
     ] 
@@ -52,7 +52,7 @@
   {% 
     set submit_classes = [
       'btn', 
-      'btn-outline-secondary', 
+      'btn-outline-info', 
       'isu-preview-button', 
       'isu-form-submit' 
     ] 
@@ -65,7 +65,7 @@
   {% 
     set submit_classes = [
       'btn', 
-      'btn-primary', 
+      'btn-success', 
       'isu-form-submit'
     ] 
   %}
@@ -82,7 +82,7 @@
     set submit_classes = [
       'btn', 
       'btn-sm', 
-      'btn-outline-primary', 
+      'btn-success', 
       'isu-form-submit'
     ] 
   %}


### PR DESCRIPTION
We are working on a fairly significant revision to the button color strategy. The system's goals are to improve the contrast of button colors to conform better with WCAG, also to establish a system of what colors different types of buttons get. For example - red is now used in forms as DANGER, and the green SUCCESS color is our create/add actions. 

Button color changes will mostly affect node add and edit pages if that box is checked in the Appearance page. Most of the user facing buttons are still going to be outlined red to match the general branding.