### PR TITLE
D8ISUTHEME-83 Update FontAwesome library from 4.5 to 4.7

### DIFF
--- a/iastate_theme.libraries.yml
+++ b/iastate_theme.libraries.yml
@@ -41,4 +41,4 @@ font-awesome:
     gpl-compatible: true
   css:
     theme:
-      'https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css': { type: external, minified: true }
+      'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css': { type: external, minified: true }


### PR DESCRIPTION
The Snapchat icon wasn't showing up in the social media footer. Updating the library version fixed it.