### PR TITLE
D8-723 Add custom theme settings for the site unit and unit url

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -153,15 +153,16 @@ body,
  * Change sitename in Drupal theme settings.
  */
 
-.isu-wordmark {
+.isu-wordmark,
+.isu-wordmark a {
   color: #ffffff;
   text-decoration: none;
 }
-  .isu-wordmark:hover {
+  .isu-wordmark a:hover {
     color: #ffffff;
-    text-decoration: none;
+    text-decoration: underline;
   }
-  .isu-wordmark:focus {
+  .isu-wordmark a:focus {
     color: #ffffff;
   }
 .isu-wordmark-logo {
@@ -170,17 +171,17 @@ body,
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
-.isu-wordmark-slogan,
+.isu-wordmark-unit,
 .isu-wordmark-sitename {
   margin-bottom: 0;
   font-weight: bold;
   font-size: 1rem;
 }
-/* If there is both a slogan and site name,
- * site name gets slogan's styling and then 
+/* If there is both a unit and site name,
+ * site name gets the unit's styling and then 
  * a border.
  */
-.isu-wordmark-sitename_slogan {
+.isu-wordmark-sitename_unit {
   margin-top: 0.5rem;
   padding-top: 0.5rem;
   font-size: 1rem;

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -122,6 +122,9 @@ function iastate_theme_preprocess(&$variables, $hook) {
   }
   // Ensure the cache varies correctly (new in Drupal 8.3).
   $variables['#cache']['contexts'][] = 'url.path.is_front';
+
+  $variables['iastate_unit_name'] = theme_get_setting('iastate_unit_name');
+  $variables['iastate_unit_url'] = theme_get_setting('iastate_unit_url');
 }
 
 /*

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -30,15 +30,30 @@
 {% extends "block.html.twig" %}
 
 {% block content %}
-  <div>
-    <a class="isu-wordmark" rel="home" href="{{ path('<front>') }}" title="{{ site_name }}">
-      <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
-      {% if site_slogan %}
-        <div class="isu-wordmark-slogan">{{ site_slogan }}</div>
-        <h1 class="isu-wordmark-sitename_slogan">{{ site_name}}</h1>
-      {% else %}
-        <h1 class="isu-wordmark-sitename">{{ site_name}}</h1>
-      {% endif %}
-    </a>
+  <div class="isu-wordmark">
+    <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
+
+    {% if iastate_unit_name %}
+
+      <div class="isu-wordmark-unit">
+        {% if iastate_unit_url %}
+          <a href="{{ iastate_unit_url }}">{{ iastate_unit_name }}</a>
+        {% else %}
+          <span>{{ iastate_unit_name }}</span>
+        {% endif %}
+      </div>
+
+      <h1 class="isu-wordmark-sitename_unit">
+        <a rel="home" href="{{ path('<front>') }}">{{ site_name }}</a>
+      </h1>
+
+    {% else %}
+
+      <h1 class="isu-wordmark-sitename">
+        <a rel="home" href="{{ path('<front>') }}">{{ site_name }}</a>
+      </h1>
+      
+    {% endif %}
   </div>
+
 {% endblock %}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -41,12 +41,35 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#description'  => t('Check this option if you\'d like to show the ISU navbar.'),
   );
 
+  // Create a section for Unit settings
+  $form['iastate_unit_settings'] = array(
+    '#type'         => 'details',
+    '#title'        => t('Unit'),
+    '#description'  => t('Name and url of official university unit, such as a department or center, if the Site Name (as set in Basic Site Settings) is not already the name of the unit.'),
+    '#weight'       => -999,
+    '#open'         => TRUE,
+    );
+
+  // Unit Name
+  $form['iastate_unit_settings']['iastate_unit_name'] = array(
+      '#type'   => 'textfield',
+      '#title'  => t('Unit Name'),
+      '#default_value'  => theme_get_setting('iastate_unit_name'),
+    );
+
+  // Unit URL
+  $form['iastate_unit_settings']['iastate_unit_url'] = array(
+      '#type'   => 'url',
+      '#title'  => t('Unit URL'),
+      '#default_value'  => theme_get_setting('iastate_unit_url'),
+    );
+
   // Create a section for footer content
   $form['iastate_footer_contact'] = array(
     '#type'         => 'details',
     '#title'        => t('Contact Info'),
     '#description'  => t('Contact information is displayed in the footer'),
-    '#weight'       => -999,
+    '#weight'       => -998,
     '#open'         => TRUE,
     );
 


### PR DESCRIPTION
To test:

* Create a Drupal 8 site with this branch of the base theme
* Try adding a unit name, then a unit name and unit URL
* If there is a unit name, it should take the place of the site name directly beneath the Logo.
* If there is a unit url, the unit name should be a link. If there is no unit url, it should not be a link.
* The site name should link to the homepage.