### PR TITLE
D8ISUTHEME-87 Redesign delete confirm page

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -597,6 +597,27 @@ article:not(.isu-user):not(.isu-search_collapse) {
   margin-bottom: 1rem;
 }
 
+/* Node form titles */
+/* Classes created via iastate_theme.theme and implemented in html.html.twig */
+
+.node-form .isu-page-title {
+  font-size: 2rem;
+}
+
+.node-form .isu-page-title .placeholder { /* placeholder class via Drupal 8 */
+  font-weight: bold;
+}
+
+.node-form_edit .isu-page-title {
+  font-weight: bold;
+  font-style: italic;
+}
+
+.node-form_edit .isu-page-title em {
+  font-style: normal;
+  font-weight: normal;
+}
+
 /* --- Unpublished Nodes --- */
 /* Classes added to unpublished nodes in node.html.twig */
 
@@ -987,10 +1008,54 @@ details {
   margin-right: 0.5rem;
 }
 
+/* --- ## Cancel Buttons --- #/
+/* Cancel buttons are links, not buttons.
+ * https://www.drupal.org/node/2250341
+ * Duplicating Bootstrap 4's btn-outline-secondary btn-sm
+ */
+
+#edit-cancel {
+  /* btn */
+  display: inline-block;
+  font-weight: 400;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border: 1px solid transparent;
+  padding: .375rem .75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border-radius: .25rem;
+  transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+  /* btn-outline-danger */
+  color: #6c757d;
+  background-color: #ffffff;
+  border-color: #6c757d;
+  /* btn-sm */
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  border-radius: 0.2rem;
+}
+
+#edit-cancel:hover {
+  color: #fff;
+  background-color: #6c757d;
+  border-color: #6c757d;
+}
+
+#edit-cancel:focus {
+    box-shadow: 0 0 0 0.2rem rgba(108,117,125,.5);
+}
+
 /* --- ## Delete Buttons --- */
 /* Delete buttons are links, not buttons.
  * https://www.drupal.org/node/2250341
- * Duplicating Bootstrap 4's btn-outline-secondary
+ * Duplicating Bootstrap 4's btn-outline-danger
  */
 
 #edit-delete {

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -125,6 +125,19 @@ function iastate_theme_preprocess(&$variables, $hook) {
 
   $variables['iastate_unit_name'] = theme_get_setting('iastate_unit_name');
   $variables['iastate_unit_url'] = theme_get_setting('iastate_unit_url');
+
+  // Check to see if it's an edit/add/ or delete node page
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  
+  if ($route_name == 'entity.node.edit_form') {
+    $variables['is_node_edit'] = 'edit';
+  }
+  elseif ($route_name == 'node.add') {
+    $variables['is_node_add'] = 'add';
+  }
+  elseif ($route_name == 'entity.node.delete_form') {
+    $variables['is_node_delete'] = 'delete';
+  }
 }
 
 /*

--- a/templates/components/confirm-form.html.twig
+++ b/templates/components/confirm-form.html.twig
@@ -1,0 +1,16 @@
+{#
+/**
+ * @file
+ * Theme override for confirm form.
+ *
+ * By default this does not alter the appearance of a form at all,
+ * but is provided as a convenience for themers.
+ *
+ * Available variables:
+ * - form: The confirm form.
+ */
+#}
+
+<p class="alert alert-danger">{{ form.description }}</p>
+
+{{ form|without('description') }}

--- a/templates/forms/input--submit.html.twig
+++ b/templates/forms/input--submit.html.twig
@@ -47,6 +47,20 @@
 
   <button{{ attributes.addClass(submit_classes) }}>{{ attributes.value }}</button>
 
+{% elseif attributes.value == 'Delete' %}
+
+  {% 
+    set submit_classes = [
+      'btn', 
+      'btn-sm', 
+      'btn-outline-danger', 
+      'isu-remove-button', 
+      'isu-form-submit'
+    ] 
+  %}
+
+  <button{{ attributes.addClass(submit_classes) }}>{{ attributes.value }}</button>
+
 {% elseif attributes.value == 'Preview' %}
 
   {% 

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -36,6 +36,9 @@
     set body_classes = [
       logged_in ? 'logged-in',
       'node-type_' ~ node_type|clean_class,
+      is_node_edit == 'edit' ? 'node-form node-form_' ~ 'edit',
+      is_node_add == 'add' ? 'node-form node-form_' ~ 'add',
+      is_node_delete == 'delete' ? 'node-form node-form_' ~ 'delete',
     ]
   %}
   <body{{ attributes.addClass(body_classes) }}>


### PR DESCRIPTION
*Goal*
- The current delete page (`node/%/delete`) was difficult to read and had the wrong colors for the buttons, making it a little unclear as to the purpose of the buttons. I wanted to make the page more deliberate and easier to use.

*What I did*
- Created the template for the confirmation page to wrap the page text in an alert
- Updated the submit buttons template to apply the proper classes to delete buttons
- Added css to manually style the cancel button which is actually a link
- Added some additional useful classes to the body to tell whether you're on a node form page

*To test*
- Create a node, then try to delete it
- Does the delete page have the warning in a red alert box, a red delete button, and a grey-outlined cancel button?
- Can you keyboard navigate to the buttons?
- Does it work on different content types?