### PR TITLE
D8-991 Increase contrast for form inputs for WCAG 2.1

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -267,6 +267,12 @@ table img {
 summary[aria-expanded="true"] {
   margin-bottom: 1rem;
 }
+
+.form-control,
+.cke_chrome {
+  /* Overrides bootstrap.min.css and editor.css for sufficient contrast */
+  border-color: #767676 !important;
+}
 .form-control:focus {
   /* Overrides bootstrap.min.css which removed focus style */
   outline: #5cb3fd auto 5px;


### PR DESCRIPTION
The border around text inputs and other fields should now be darker to comply with WCAG 2.1's new standard.