### PR TITLE
D8-1005 Make more form field labels bold.

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -862,7 +862,8 @@ details {
 /* Trying to hit the main labels in some of these fields. */
 .isu-form-type_managed-file > label,
 .isu-form-type_textarea label,
-.filter-wrapper .isu-form-type_select label {
+.isu-form-type_select label,
+.isu-form-type_entity-autocomplete label {
   /* .filter-wrapper via Drupal 8 */
   font-weight: 700;
 }


### PR DESCRIPTION
Autocomplete fields like tags, and select fields should now have bold labels.