### PR TITLE
D8-1078 Styles help text on formatted text areas.

### DIFF
--- a/templates/forms/text-format-wrapper.html.twig
+++ b/templates/forms/text-format-wrapper.html.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Theme override for a text format-enabled form element.
+ *
+ * Available variables:
+ * - children: Text format element children.
+ * - description: Text format element description.
+ * - attributes: HTML attributes for the containing element.
+ * - aria_description: Flag for whether or not an ARIA description has been
+ *   added to the description container.
+ *
+ * @see template_preprocess_text_format_wrapper()
+ */
+#}
+
+{%
+  set description_classes = [
+    'description',
+    'isu-form-element-description',
+    'mt-2',
+    description_display == 'invisible' ? 'visually-hidden',
+  ]
+%}
+
+<div class="js-text-format-wrapper js-form-item form-item">
+  {{ children }}
+  {% if description %}
+    <div{{ attributes.addClass(description_classes) }}>{{ description }}</div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Help text added to formatted text areas was not getting the `isu-form-element-description` class because unlike other field types, the `description` is added to formatted text areas with the `text-format-wrapper.html.twig` file.

**To test:** 
Add help text to a formatted text field. Does it appear a smaller light grey like help text on other fields?