### PR TITLE
D8ISUTHEME-92 Add Okta and Workday links to Sign-Ons

### DIFF
--- a/templates/parts/isu-navbar.html.twig
+++ b/templates/parts/isu-navbar.html.twig
@@ -58,7 +58,9 @@
         <li><a href="https://canvas.iastate.edu/">Canvas</a></li>
         <li><a href="https://iastate.box.com/">CyBox</a></li>
         <li><a href="http://cymail.iastate.edu/">CyMail</a></li>
+        <li><a href="https://login.iastate.edu/">Okta</a></li>
         <li><a href="https://outlook.iastate.edu/">Outlook</a></li>
+        <li><a href="https://workday.iastate.edu/">Workday</a></li>
         <li><a href="https://web.iastate.edu/signons">More Sign Ons...</a></li>
       </ul>
     </li>


### PR DESCRIPTION
Do you see the Okta and Workday links in the Sign-ons dropdown? Do they go to the right place?