### PR TITLE
D8ISUTHEME-93 Making colspan/rowspan tables responsive and properly styled.

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -209,6 +209,15 @@ caption {
   border-top: 1px solid #cccccc;
 }
 
+/* rowspan and colspan */
+.table th[colspan]:not([colspan="1"]),
+.table th[rowspan]:not([rowspan="1"]),
+.table td[colspan]:not([colspan="1"]),
+.table td[rowspan]:not([rowspan="1"]) {
+  border-right: 1px solid #dddd;
+  border-left: 1px solid #ddd;
+}
+
 /* --------------------------------------  */
 /* ## IMAGES
 /* --------------------------------------  */

--- a/js/isu-responsivetables.js
+++ b/js/isu-responsivetables.js
@@ -32,8 +32,21 @@ $(document).ready(function() {
   bothHeader.addClass('isu-table-both');
   bothHeader.removeClass('isu-table-none isu-table-row isu-table-col');
   
+  // All responsive tables
+  table.addClass('isu-responsive-table table');
+
   // Colspan or Rowspan
-  var responsiveClasses = 'isu-table-none isu-table-row isu-table-col';
+  
+  /* Remove extranneous colspan and rowspan */
+
+  $('th[colspan="1"]').removeAttr('colspan');
+  $('th[rowspan="1"]').removeAttr('rowspan');
+  $('td[colspan="1"]').removeAttr('colspan');
+  $('td[rowspan="1"]').removeAttr('rowspan');
+
+  /* Then apply the correct classes for colspan/rowspan tables */
+
+  var responsiveClasses = 'isu-responsive-table isu-table-none isu-table-row isu-table-col';
 
   var tdColFreeze = $(table.has('td[colspan]'));
       tdColFreeze.addClass('isu-table-freeze');
@@ -50,9 +63,6 @@ $(document).ready(function() {
   var thRowFreeze = $(table.has('th[rowspan]'));
       thRowFreeze.addClass('isu-table-freeze');
       thRowFreeze.removeClass(responsiveClasses);
-
-  // All responsive tables
-  table.addClass('isu-responsive-table table');
 
 /* 
  * Now apply any jQuery needed to make the tables responsive


### PR DESCRIPTION
Right now tables with merged cells (colspan/rowspan) are not responsive. They should be horizontally scrollable without illegible smushing. That, and merged cells don't have enough borders to make sense. 

**To test:**
1. Make sure that your text formatter includes `<td rowspan colspan> <th rowspan colspan>`
2. Make some tables and merge cells both horizontally and vertically. 
3. When you publish the page, do the merged cells have nice borders that make sense?
4. When you narrow the screen, can you read the table with a horizontal scroll?
5. Go back and reverse the cell merging (I think you have to do the split commands). 
6. Publish. Does the table do the responsive thing moving content into a column?