### PR TITLE
Stop tables from stretching to full width in CKEditor

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -329,6 +329,7 @@ body.cke_editable figure figcaption {
  */
 
  body.cke_editable table {
+  display: block;
   max-width: 100%;
   margin-bottom: 1rem;
   background-color: transparent;

--- a/css/base.css
+++ b/css/base.css
@@ -329,8 +329,7 @@ body.cke_editable figure figcaption {
  */
 
  body.cke_editable table {
-  display: block;
-  max-width: 100%;
+  width: auto;
   margin-bottom: 1rem;
   background-color: transparent;
 }


### PR DESCRIPTION
To test: when making tables in CKEditor do the tables no longer stretch out full width? For our D8 platform, do the Basic and Striped styles also stop stretching in the editor?

They should already not be stretching on published pages.