### PR TITLE
D8-1394 Make block titles h2

### DIFF
--- a/templates/blocks/block.html.twig
+++ b/templates/blocks/block.html.twig
@@ -36,8 +36,8 @@
 <div{{ attributes.addClass(block_classes) }}>
   {{ title_prefix }}
   {% if label %}
-    {% set block_title_classes = ['isu-block-title', 'h4'] %}
-    <h1{{ title_attributes.addClass(block_title_classes) }}>{{ label }}</h1> 
+    {% set block_title_classes = ['isu-block-title', 'h3'] %}
+    <h2{{ title_attributes.addClass(block_title_classes) }}>{{ label }}</h2> 
   {% endif %}
   {{ title_suffix }}
   {% block content %}


### PR DESCRIPTION
We don't reliably have the ability to wrap blocks in `article` tags, so it's a safer bet to use `h2`.