### PR TITLE
D8ISUTHEME-98

### DIFF
--- a/templates/parts/site-navbar.html.twig
+++ b/templates/parts/site-navbar.html.twig
@@ -27,7 +27,7 @@
 
       <button class="isu-search_toggler" id="isu-search_toggler">
         <span class="fa fa-search isu-search_toggler-icon" aria-hidden="true"></span>
-        <span class="isu-search_toggler-label">Open search menu</span>
+        <span class="isu-search_toggler-label">Open search bar</span>
       </button> 
 
       <div class="col-lg isu-col-header-second isu-col-header-second_has-search">

--- a/templates/parts/site-navbar.html.twig
+++ b/templates/parts/site-navbar.html.twig
@@ -27,7 +27,7 @@
 
       <button class="isu-search_toggler" id="isu-search_toggler">
         <span class="fa fa-search isu-search_toggler-icon" aria-hidden="true"></span>
-        <span class="isu-search_toggler-label">Search</span>
+        <span class="isu-search_toggler-label">Open search menu</span>
       </button> 
 
       <div class="col-lg isu-col-header-second isu-col-header-second_has-search">


### PR DESCRIPTION
Small accessibility improvement.

There is a button element to open the search bar on narrow screens. The text just says 'Search' but that's the same text as the Search submit button, and that's not actually what it's doing. The button opens the search box. So that's what it says now.

This text is visually hidden so there won't be a visual change. But you can inspect the HTML to see the change. 