### PR TITLE
D8ISUTHEME-103

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -1,4 +1,5 @@
 isu_navbar: 1
+gold_border: 1
 features:
   favicon: true
 iastate_unit_name: ''

--- a/css/theme.css
+++ b/css/theme.css
@@ -85,6 +85,9 @@ body,
 .isu-site-navbar {
   padding: 0;
   background-color: #cc0000;
+}
+/* The gold border is optional and can be hidden in theme settings */
+.isu-gold-border {
   border-bottom: 9px solid #f1be48;
 }
 .isu-row-site-navbar {

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -148,6 +148,7 @@ function iastate_theme_preprocess(&$variables, $hook) {
 
 function iastate_theme_preprocess_page(&$variables) {
   $variables['isu_navbar'] = theme_get_setting('isu_navbar');
+  $variables['gold_border'] = theme_get_setting('gold_border');
 
   $variables['theme_path'] = base_path() . $variables['directory'];
 

--- a/templates/parts/site-navbar.html.twig
+++ b/templates/parts/site-navbar.html.twig
@@ -12,7 +12,13 @@
  */
 #}
 
-<header class="isu-site-navbar" role="banner" aria-label="Site header">
+{% set site_navbar_classes = [
+  'isu-site-navbar',
+  gold_border ? 'isu-gold-border'
+  ] 
+%}
+
+<header{{ attributes.addClass(site_navbar_classes) }} role="banner" aria-label="Site header">
   <div class="container">
     <div class="row isu-row-site-navbar">
 

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -41,6 +41,14 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#description'  => t('Check this option if you\'d like to show the ISU navbar.'),
   );
 
+  // Set up the checkbox to show/hide the gold border on the Site Header
+  $form['iastate_theme_settings']['gold_border'] = array(
+    '#type'         => 'checkbox',
+    '#title'        => t('Show gold border'),
+    '#default_value' => theme_get_setting('gold_border'),
+    '#description'  => t('Show or hide the gold border below the red Site Navbar header.'),
+  );
+
   // Create a section for Unit settings
   $form['iastate_unit_settings'] = array(
     '#type'         => 'details',


### PR DESCRIPTION
This branch makes a theme setting to show/hide the gold border below the red Site Navbar. 

To test:

1. Create a site using this theme (not our subtheme)
2. The gold bar should be there.
3. Go to theme settings
4. Is there a checkbox for the gold border in the Site Navbar section at the top? Hope so.
5. It should be checked by default.
6. Uncheck it and save
7. The gold bar should disappear