### PR TITLE
D8ISUTHEME-106 Only show sidebars if blocks have content

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -82,17 +82,17 @@
   <div class="container">
     <div class="row">
 
-      {% if page.sidebar_first and page.sidebar_second %}
+      {% if page.sidebar_first|render and page.sidebar_second|render %}
         {% set content_classes = 'col-lg-6' %}
         {% set sidebar_classes = 'col-lg-3' %}
-      {% elseif page.sidebar_first or page.sidebar_second %}
+      {% elseif page.sidebar_first|render or page.sidebar_second|render %}
         {% set content_classes = 'col-lg-9' %}
         {% set sidebar_classes = 'col-lg-3' %}
       {% else %}
         {% set content_classes = 'col-lg-12' %}
       {% endif %}
 
-      {% if page.sidebar_first %}
+      {% if page.sidebar_first|render %}
         <div class="isu-page-column isu-sidebar isu-sidebar-first {{sidebar_classes}}">
           <aside role="complementary">
             {{ page.sidebar_first }}
@@ -100,13 +100,13 @@
         </div>
       {% endif %}
 
-      {% if page.content %}
+      {% if page.content|render %}
         <div class="isu-page-column isu-content-column {{content_classes}}">
           {{ page.content }}
         </div>
       {% endif %}
 
-      {% if page.sidebar_second %}
+      {% if page.sidebar_second|render %}
         <div class="isu-page-column isu-sidebar isu-sidebar-second {{sidebar_classes}}">
           <aside role="complementary">
             {{ page.sidebar_second }}


### PR DESCRIPTION
Right now if a block exists in a theme region (say a View block) and it has no content (say you checked the option to hide if empty), the theme region still renders, leaving a gap. This pull request makes sure the sidebars are hidden if they are empty. 

**To test:**
1. Make a plain D8 site (not the iastate8 platform) and set this theme as default.
2. Create some kind of throw-away View block, something to show some content.
3. Under the View's advanced options, choose Hide if empty.
4. Place the block in a sidebar (remove any other blocks that might be in the sidebar of choice)

Confirm the sidebar and block shows up if the View has content.
Confirm the sidebar doesn't show up if the View is empty.