### PR TITLE
D8ISUTHEME-107 Improve UI for adding images.

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -408,3 +408,44 @@ body.cke_editable table[border] td {
   border-bottom-color: #808080;
   border-top-color: #808080;
 }
+
+/* --------------------------------------  */
+/* ## FORM
+/* --------------------------------------  */
+
+/* --- Add image UI --- */
+
+.form-item-field-thumbnail-0 img {
+  width: 700px;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield {
+  display: block;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield label {
+  display: block;
+  text-align: left;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield .description {
+  padding-left: 0;
+}
+
+.isu-form-type_managed-file img {
+  margin-bottom: 1rem;
+}
+
+.isu-form-type_managed-file .isu-remove-button {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+/* CKEditor */
+div[id|='edit-attributes-data-align'] {
+  display: flex;
+}
+
+.form-item-attributes-data-align .form-radio {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Our UIs for adding images as fields or in CKEditor could use some improvement. This branch affects two things: 

1. When there is an image field. It adds a little spacing and moves the alternative text field to the next line.
2. When adding an image via CKeditor. Mostly, aligning the alignment options in a row instead of a column. 

**To test:** 
1. Look at an image field and confirm it has the new design.
2. Add an image in CKeditor and confirm it has the new design.

Screenshots are in the last comment of the ticket: https://isubit.atlassian.net/browse/D8ISUTHEME-107