### PR TITLE
D8ISUTHEME-110 Stop thumbnail preview sizing up

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -415,10 +415,6 @@ body.cke_editable table[border] td {
 
 /* --- Add image UI --- */
 
-.form-item-field-thumbnail-0 img {
-  width: 700px;
-}
-
 .isu-form-type_managed-file .isu-form-type_textfield {
   display: block;
 }


### PR DESCRIPTION
**Hotfix**

1. Add/edit a Blog, Event, News, and Projects posts
2. Add a thumbnail image
3. Confirm the thumbnail preview isn't huge. Should be 200x120 (the image style that appears in a teaser)