### PR TITLE
D8ISUTHEME-112 Add focus states to dropbuttons

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1193,6 +1193,12 @@ details {
   padding: 0.25rem 0.5rem;
   text-decoration: none;
 }
+/* Imitate browser focus state */
+.js .dropbutton a:focus,
+.dropbutton-toggle button:focus {
+  box-shadow: inset 0 0 1px 2px #5096ff;
+}
+
 
 /* --- ## Multiple values table --- */
 /* Overrides tabledrag.module.css */


### PR DESCRIPTION
To test...

1. Make sure that this base theme (or our subtheme) is being used for admin interfaces, like when you're logged in as a shib user
2. Go to the manage menu UI
3. Add a new link so you have access to the Operations dropbutton
4. Use the keyboard to use that dropdown. Both the main part and the dropdown arrow are separately focusable. 

Confirm you see a light blue inner shadow when you are focused on the Edit, Arrow, and Delete parts of the dropbutton.