### PR TITLE
Development

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -415,10 +415,6 @@ body.cke_editable table[border] td {
 
 /* --- Add image UI --- */
 
-.form-item-field-thumbnail-0 img {
-  width: 700px;
-}
-
 .isu-form-type_managed-file .isu-form-type_textfield {
   display: block;
 }

--- a/css/base.css
+++ b/css/base.css
@@ -408,3 +408,44 @@ body.cke_editable table[border] td {
   border-bottom-color: #808080;
   border-top-color: #808080;
 }
+
+/* --------------------------------------  */
+/* ## FORM
+/* --------------------------------------  */
+
+/* --- Add image UI --- */
+
+.form-item-field-thumbnail-0 img {
+  width: 700px;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield {
+  display: block;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield label {
+  display: block;
+  text-align: left;
+}
+
+.isu-form-type_managed-file .isu-form-type_textfield .description {
+  padding-left: 0;
+}
+
+.isu-form-type_managed-file img {
+  margin-bottom: 1rem;
+}
+
+.isu-form-type_managed-file .isu-remove-button {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+/* CKEditor */
+div[id|='edit-attributes-data-align'] {
+  display: flex;
+}
+
+.form-item-attributes-data-align .form-radio {
+  margin-bottom: 0;
+}

--- a/css/theme.css
+++ b/css/theme.css
@@ -1193,6 +1193,12 @@ details {
   padding: 0.25rem 0.5rem;
   text-decoration: none;
 }
+/* Imitate browser focus state */
+.js .dropbutton a:focus,
+.dropbutton-toggle button:focus {
+  box-shadow: inset 0 0 1px 2px #5096ff;
+}
+
 
 /* --- ## Multiple values table --- */
 /* Overrides tabledrag.module.css */

--- a/css/theme.css
+++ b/css/theme.css
@@ -593,6 +593,9 @@ body,
   margin-top: 1rem;
   margin-bottom: 2rem;
 }
+.isu-sidebar {
+  margin-top: 2rem;
+}
 .isu-page-title {
   margin-top: 1rem;
   margin-bottom: 2rem;
@@ -713,8 +716,13 @@ article:not(.isu-user):not(.isu-search_collapse) {
   margin-bottom: 1rem;
 }
 .isu-block-title {
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
   line-height: 1.25;
+  border-bottom: 1px solid #bbbbbb;
+}
+.isu-sidebar .isu-block-title {
+  font-size: 1.15rem;
 }
 
 /* -------------------------------------- */


### PR DESCRIPTION
This release has just two things.

1. Content block titles, like those placed in sidebars and landing pages, have borders under titles now

2. The D8 component 'dropbutton' as seen on a shib user's Manage Menu screen how have visual focus style for easier keyboard navigation

