### PR TITLE
Allow custom alt text for header and footer logos

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -2,10 +2,12 @@ isu_navbar: 1
 gold_border_hidden: 0
 features:
   favicon: true
+iastate_logo_alt: ''
 iastate_unit_name: ''
 iastate_unit_url: ''
 iastate_footer_logo_path: themes/contrib/iastate_theme/isu-stacked.svg
 iastate_footer_logo_url: 'https://www.iastate.edu/'
+iastate_footer_logo_alt: ''
 iastate_contact_address: "2221 Wanda Daley Dr\n2nd Floor ASB\nAmes, IA 50011"
 iastate_contact_email: 'theme@iastate.edu'
 iastate_contact_phone: '515-294-6654'

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -141,9 +141,20 @@ function iastate_theme_preprocess(&$variables, $hook) {
 }
 
 /*
+ * Implements theme_preprocess_block().
+ *
+ * Make theme settings available in block templates
+ */
+
+function iastate_theme_preprocess_block(&$variables) {
+  $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
+
+}
+
+/*
  * Implements theme_preprocess_page().
  *
- * Make theme settings available in templates
+ * Make theme settings available in page templates
  */
 
 function iastate_theme_preprocess_page(&$variables) {
@@ -154,6 +165,7 @@ function iastate_theme_preprocess_page(&$variables) {
 
   $variables['iastate_footer_logo_path'] = theme_get_setting('iastate_footer_logo_path');
   $variables['iastate_footer_logo_url'] = theme_get_setting('iastate_footer_logo_url');
+  $variables['iastate_footer_logo_alt'] = theme_get_setting('iastate_footer_logo_alt');
 
   $variables['iastate_contact_title'] = theme_get_setting('iastate_contact_title');
   $variables['iastate_contact_address'] = theme_get_setting('iastate_contact_address');

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -31,7 +31,7 @@
 
 {% block content %}
   <div class="isu-wordmark">
-    <img class="isu-wordmark-logo" src="{{ site_logo }}" alt="Iowa State University Logo">
+    <img class="isu-wordmark-logo" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
 
     {% if iastate_unit_name %}
 

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -24,7 +24,7 @@
             {% if iastate_footer_logo_url %}
               <a href="{{ iastate_footer_logo_url }}">
             {% endif %}
-                <img class="isu-footer-logo" src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" {% if iastate_footer_logo_alt %} alt="{{ iastate_footer_logo_alt }}" {% else %} alt="Iowa State University" {% endif %}>
+                <img class="isu-footer-logo" src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" {% if iastate_footer_logo_alt %} alt="{{ iastate_footer_logo_alt }}" {% else %} alt="Iowa State University logo" {% endif %}>
             {% if iastate_footer_logo_url %}
               </a>
             {% endif %}

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -24,7 +24,7 @@
             {% if iastate_footer_logo_url %}
               <a href="{{ iastate_footer_logo_url }}">
             {% endif %}
-                <img class="isu-footer-logo" src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" alt="Iowa State University">
+                <img class="isu-footer-logo" src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" {% if iastate_footer_logo_alt %} alt="{{ iastate_footer_logo_alt }}" {% else %} alt="Iowa State University" {% endif %}>
             {% if iastate_footer_logo_url %}
               </a>
             {% endif %}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -23,6 +23,14 @@
  */
 function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
 
+  // Logo alt text
+  $form['logo']['iastate_logo_alt'] = array(
+    '#type'   => 'textfield',
+    '#title'  => t('Logo alt text'),
+    '#default_value'  => theme_get_setting('iastate_logo_alt'),
+    '#description' => t('If left blank the alt text will be Iowa State University logo'),
+  );
+
   // Create a section for ISU theme settings
   $form['iastate_theme_settings'] = array(
     '#type'         => 'details',
@@ -130,80 +138,80 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
   
   // 1
   $form['iastate_footer_associates']['iastate_associate1_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 1 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate1_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 1 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate1_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate1_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 1 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate1_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 1 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate1_url'),
+  );
 
   // 2
   $form['iastate_footer_associates']['iastate_associate2_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 2 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate2_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 2 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate2_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate2_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 2 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate2_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 2 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate2_url'),
+  );
 
   // 3
   $form['iastate_footer_associates']['iastate_associate3_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 3 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate3_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 3 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate3_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate3_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 3 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate3_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 3 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate3_url'),
+  );
 
   // 4
   $form['iastate_footer_associates']['iastate_associate4_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 4 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate4_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 4 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate4_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate4_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 4 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate4_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 4 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate4_url'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate5_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 5 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate5_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 5 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate5_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate5_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 5 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate5_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 5 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate5_url'),
+  );
 
   // 6
   $form['iastate_footer_associates']['iastate_associate6_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Associate 6 Title'),
-      '#default_value'  => theme_get_setting('iastate_associate6_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Associate 6 Title'),
+    '#default_value'  => theme_get_setting('iastate_associate6_title'),
+  );
 
   $form['iastate_footer_associates']['iastate_associate6_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Associate 6 URL'),
-      '#default_value'  => theme_get_setting('iastate_associate6_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Associate 6 URL'),
+    '#default_value'  => theme_get_setting('iastate_associate6_url'),
+  );
 
   // Create a section for social media links
   $form['iastate_footer_social'] = array(
@@ -216,94 +224,94 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
   
   // 1
   $form['iastate_footer_social']['iastate_social1_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 1 Title'),
-      '#default_value'  => theme_get_setting('iastate_social1_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 1 Title'),
+    '#default_value'  => theme_get_setting('iastate_social1_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social1_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 1 URL'),
-      '#default_value'  => theme_get_setting('iastate_social1_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 1 URL'),
+    '#default_value'  => theme_get_setting('iastate_social1_url'),
+  );
 
   // 2
   $form['iastate_footer_social']['iastate_social2_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 2 Title'),
-      '#default_value'  => theme_get_setting('iastate_social2_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 2 Title'),
+    '#default_value'  => theme_get_setting('iastate_social2_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social2_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 2 URL'),
-      '#default_value'  => theme_get_setting('iastate_social2_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 2 URL'),
+    '#default_value'  => theme_get_setting('iastate_social2_url'),
+  );
 
   // 3
   $form['iastate_footer_social']['iastate_social3_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 3 Title'),
-      '#default_value'  => theme_get_setting('iastate_social3_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 3 Title'),
+    '#default_value'  => theme_get_setting('iastate_social3_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social3_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 3 URL'),
-      '#default_value'  => theme_get_setting('iastate_social3_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 3 URL'),
+    '#default_value'  => theme_get_setting('iastate_social3_url'),
+  );
 
   // 4
   $form['iastate_footer_social']['iastate_social4_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 4 Title'),
-      '#default_value'  => theme_get_setting('iastate_social4_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 4 Title'),
+    '#default_value'  => theme_get_setting('iastate_social4_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social4_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 4 URL'),
-      '#default_value'  => theme_get_setting('iastate_social4_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 4 URL'),
+    '#default_value'  => theme_get_setting('iastate_social4_url'),
+  );
 
   // 5
   $form['iastate_footer_social']['iastate_social5_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 5 Title'),
-      '#default_value'  => theme_get_setting('iastate_social5_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 5 Title'),
+    '#default_value'  => theme_get_setting('iastate_social5_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social5_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 5 URL'),
-      '#default_value'  => theme_get_setting('iastate_social5_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 5 URL'),
+    '#default_value'  => theme_get_setting('iastate_social5_url'),
+  );
 
   // 6
   $form['iastate_footer_social']['iastate_social6_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 6 Title'),
-      '#default_value'  => theme_get_setting('iastate_social6_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 6 Title'),
+    '#default_value'  => theme_get_setting('iastate_social6_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social6_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 6 URL'),
-      '#default_value'  => theme_get_setting('iastate_social6_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 6 URL'),
+    '#default_value'  => theme_get_setting('iastate_social6_url'),
+  );
 
   // 7
   $form['iastate_footer_social']['iastate_social7_title'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Social 7 Title'),
-      '#default_value'  => theme_get_setting('iastate_social7_title'),
-    );
+    '#type'   => 'textfield',
+    '#title'  => t('Social 7 Title'),
+    '#default_value'  => theme_get_setting('iastate_social7_title'),
+  );
 
   $form['iastate_footer_social']['iastate_social7_url'] = array(
-      '#type'   => 'url',
-      '#title'  => t('Social 7 URL'),
-      '#default_value'  => theme_get_setting('iastate_social7_url'),
-    );
+    '#type'   => 'url',
+    '#title'  => t('Social 7 URL'),
+    '#default_value'  => theme_get_setting('iastate_social7_url'),
+  );
 
   // Create a section for footer logo
   $form['iastate_footer_logo'] = array(
@@ -314,16 +322,24 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
   );
 
   $form['iastate_footer_logo']['iastate_footer_logo_path'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Path to custom footer logo'),
-      '#description' => t('Examples: logo.svg (for a file in the public filesystem), public://logo.svg, or themes/contrib/iastate_theme/logo.svg.'),
-      '#default_value'  => theme_get_setting('iastate_footer_logo_path'),
+    '#type'   => 'textfield',
+    '#title'  => t('Path to custom footer logo'),
+    '#description' => t('Examples: logo.svg (for a file in the public filesystem), public://logo.svg, or themes/contrib/iastate_theme/logo.svg.'),
+    '#default_value'  => theme_get_setting('iastate_footer_logo_path'),
   ); 
 
   $form['iastate_footer_logo']['iastate_footer_logo_url'] = array(
-      '#type'   => 'textfield',
-      '#title'  => t('Custom footer logo url'),
-      '#description' => t('Link the footer logo to a different website.'),
-      '#default_value'  => theme_get_setting('iastate_footer_logo_url'),
+    '#type'   => 'textfield',
+    '#title'  => t('Custom footer logo url'),
+    '#description' => t('Link the footer logo to a different website.'),
+    '#default_value'  => theme_get_setting('iastate_footer_logo_url'),
+  );
+
+  // Foooter logo alt text
+  $form['iastate_footer_logo']['iastate_footer_logo_alt'] = array(
+    '#type'   => 'textfield',
+    '#title'  => t('Footer logo alt text'),
+    '#default_value'  => theme_get_setting('iastate_footer_logo_alt'),
+    '#description' => t('If left blank the alt text will be Iowa State University logo'),
   );
 }


### PR DESCRIPTION
To test:

1. On a plain install of Drupal with just this base theme ...
2. Confirm the alt text on the header and footer logos are in place without changing anything
3. Go to the theme settings
4. Confirm there are now fields for the logo and footer logo
5. Test those fields by filing them out, saving, and confirming the alt text changed