### PR TITLE
Add theme setting to hide the copyright

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -1,5 +1,6 @@
 isu_navbar: 1
 gold_border_hidden: 0
+iastate_copyright_hidden: 0
 features:
   favicon: true
 iastate_logo_alt: ''

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -138,6 +138,8 @@ function iastate_theme_preprocess(&$variables, $hook) {
   elseif ($route_name == 'entity.node.delete_form') {
     $variables['is_node_delete'] = 'delete';
   }
+
+  $variables['iastate_copyright_hidden'] = theme_get_setting('iastate_copyright_hidden');
 }
 
 /*
@@ -160,7 +162,7 @@ function iastate_theme_preprocess_block(&$variables) {
 function iastate_theme_preprocess_page(&$variables) {
   $variables['isu_navbar'] = theme_get_setting('isu_navbar');
   $variables['gold_border_hidden'] = theme_get_setting('gold_border_hidden');
-
+  
   $variables['theme_path'] = base_path() . $variables['directory'];
 
   $variables['iastate_footer_logo_path'] = theme_get_setting('iastate_footer_logo_path');

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -150,18 +150,22 @@
 
       <div class="col-sm-6 col-md-6 col-lg-3">
 
-        <div class="mb-3">
-          <h2 class="visually-hidden">Copyright Information</h2>
+        {% if iastate_copyright_hidden %}
+          {# Show nothing if the copyright is hidden #}
+        {% else %}
+          <div class="mb-3">
+            <h2 class="visually-hidden">Copyright Information</h2>
 
-          <p class="isu-copyright">Copyright © <script>document.write(new Date().getFullYear());</script><br>Iowa State University<br>of Science and Technology<br>All rights reserved.</p>
+            <p class="isu-copyright">Copyright © <script>document.write(new Date().getFullYear());</script><br>Iowa State University<br>of Science and Technology<br>All rights reserved.</p>
 
-          <h2 class="visually-hidden">Legal and Privay Links</h2>
-          <ul class="isu-legal-menu">
-            <li><a href="http://www.policy.iastate.edu/policy/discrimination">Non-discrimination Policy</a></li>
-            <li><a href="http://www.policy.iastate.edu/electronicprivacy">Privacy Policy</a></li>
-            <li><a href="http://digitalaccess.iastate.edu">Digital Access &amp; Accessibility</a></li>
-          </ul>
-        </div>
+            <h2 class="visually-hidden">Legal and Privay Links</h2>
+            <ul class="isu-legal-menu">
+              <li><a href="http://www.policy.iastate.edu/policy/discrimination">Non-discrimination Policy</a></li>
+              <li><a href="http://www.policy.iastate.edu/electronicprivacy">Privacy Policy</a></li>
+              <li><a href="http://digitalaccess.iastate.edu">Digital Access &amp; Accessibility</a></li>
+            </ul>
+          </div>
+        {% endif %}
 
         {% if page.footer_fourth %}
           {{ page.footer_fourth }}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -57,6 +57,14 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#description'  => t('Check this option to hide the gold border on the red header.'),
   );
 
+  // Set up the checkbox to show/hide the copyright
+  $form['iastate_theme_settings']['iastate_copyright_hidden'] = array(
+    '#type'         => 'checkbox',
+    '#title'        => t('Hide copyright'),
+    '#default_value' => theme_get_setting('iastate_copyright_hidden'),
+    '#description'  => t('Check this option to hide the copyright and legal links in the footer.'),
+  );
+
   // Create a section for Unit settings
   $form['iastate_unit_settings'] = array(
     '#type'         => 'details',
@@ -335,7 +343,6 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#default_value'  => theme_get_setting('iastate_footer_logo_url'),
   );
 
-  // Foooter logo alt text
   $form['iastate_footer_logo']['iastate_footer_logo_alt'] = array(
     '#type'   => 'textfield',
     '#title'  => t('Footer logo alt text'),


### PR DESCRIPTION
In the rare case we need to hide the copyright, here's a checkbox for that.

1. On a plain Drupal 8 site with this base theme
2. Confirm the copyright is still in place without changing anything
3. Go to the theme settings and check the new box to hide the copyright.
4. Save
5. Confirm the copyright is gone