### PR TITLE
D8ISUTHEME-126

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -77,6 +77,9 @@ a:hover { /* Overrides bootstrap.min.css */
 a:hover img {
   outline: #5cb3fd auto 5px;
 }
+a.btn {
+  white-space: unset;
+}
 a.btn,
 a.badge,
 a.button,


### PR DESCRIPTION
By default Bootstrap 4 doesn't allow text in buttons to wrap. This has caused some problems with the the grid system if there is a button with long text. 

The way I tested this was to use a three column row in Layout Builder and put a very long link in a Text Card, then make it a button with the Style dropdown. 

Without this fix, the button will make it's column too big, throwing off the grid. With this fix, the button text will wrap.