### PR TITLE
D8ISUTHEME-127 Increase horizontal padding of main menu items

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -454,9 +454,11 @@ body,
   max-height: 100vh;
 }
 
-.isu-nav-link.nav-link { /* .nav-link via Bootstrap 4, for specificity */
-  padding-right: 1em;
-  padding-left: 1em;
+.isu-nav-link.nav-link { 
+  /* .nav-link via Bootstrap 4, for specificity */
+  /* Must override .navbar-expand-lg */
+  padding-right: 1em !important;
+  padding-left: 1em !important;
   color: #333333;
 }
   .isu-nav-link:hover {

--- a/css/theme.css
+++ b/css/theme.css
@@ -457,8 +457,8 @@ body,
 .isu-nav-link.nav-link { 
   /* .nav-link via Bootstrap 4, for specificity */
   /* Must override .navbar-expand-lg */
-  padding-right: 1em !important;
-  padding-left: 1em !important;
+  padding-right: 0.75em !important;
+  padding-left: 0.75em !important;
   color: #333333;
 }
   .isu-nav-link:hover {


### PR DESCRIPTION
This PR adds more horizontal padding to main menu items. I think this helps distinguish the menu items especially when some have dropdown arrows or there are many items. 

The left and right padding should have increased from `0.5em` to `0.75em`