### PR TITLE
D8ISUTHEME-134 Form styling fixes

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -936,7 +936,9 @@ details {
 .isu-form-type_textfield label,
 .isu-form-type_email label,
 .isu-form-type_tel label,
-.isu-form-type_url label {
+.isu-form-type_url label,
+.isu-form-type_date label,
+.isu-form-type_number label {
   /* .filter-wrapper via Drupal 8 */
   font-weight: 700;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -960,21 +960,12 @@ details {
   border-radius: 0.25rem;
   border: 1px solid #d8d8d8;
 }
-.isu-fieldset .isu-fieldset {
-  margin: 0;
-  padding: 0;
-  border-radius: 0;
-  border: 0;
-}
 .isu-legend {
   display: inline-block;
   width: auto;
   padding: 0 0.5rem;
   font-size: 1rem;
   font-weight: 700;
-}
-.isu-fieldset .isu-fieldset .isu-legend {
-  padding: 0;
 }
 
 /* --- ## Summary --- */

--- a/templates/forms/form-element.html.twig
+++ b/templates/forms/form-element.html.twig
@@ -67,6 +67,7 @@
     description_display == 'invisible' ? 'visually-hidden',
   ]
 %}
+
 <div{{ attributes.addClass(element_classes) }}>
   {% if label_display in ['before', 'invisible'] %}
     {{ label }}
@@ -87,7 +88,7 @@
     {{ label }}
   {% endif %}
   {% if errors %}
-    <div class="form-item--error-message">
+    <div class="form-item--error-message alert alert-danger" id="{{ error_id }}" role="alert">
       {{ errors }}
     </div>
   {% endif %}

--- a/templates/forms/input--number.html.twig
+++ b/templates/forms/input--number.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override for an 'textfield' #type form element.
+ *
+ * Available variables:
+ * - attributes: A list of HTML attributes for the input element.
+ * - children: Optional additional rendered elements.
+ *
+ * @see template_preprocess_input()
+ */
+#}
+
+{% 
+  set input_classes = [
+    'form-control', 
+    'isu-form-control', 
+    'isu-form-control_number'
+  ] 
+%}
+
+<input{{ attributes.addClass(input_classes) }} />{{ children }}


### PR DESCRIPTION
This covers the portion of the form styling updates from this ticket that pertain to default Drupal elements. (https://isubit.atlassian.net/browse/D8ISUTHEME-134)

**Things to test:**

- Is the number field label on a content type bold?
- Is the date field label on a content type bold?
- Does the actual number field get the nice Bootstrap 4 style?
- Do fieldsets within fieldsets get the fieldset styling?

See the screenshot in the ticket for those visuals.

**Things not to test:** 
- The error message HTML now includes some missing attributes. Just must have missed them. You can check out the commit to see what I mean.