### PR TITLE
D8ISUTHEME-135 Remove now redundant WAI-ARIA roles on landmarks.

### DIFF
--- a/templates/blocks/block--system-menu-block.html.twig
+++ b/templates/blocks/block--system-menu-block.html.twig
@@ -41,7 +41,7 @@
   ]
 %}
 
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
+<nav aria-labelledby="{{ heading_id }}"{{ attributes|without('role', 'aria-labelledby') }}>
   
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}

--- a/templates/book/book-navigation.html.twig
+++ b/templates/book/book-navigation.html.twig
@@ -29,7 +29,7 @@
  */
 #}
 {% if tree or has_links %}
-  <nav role="navigation" aria-labelledby="book-label-{{ book_id }}" class="mt-3">
+  <nav aria-labelledby="book-label-{{ book_id }}" class="mt-3">
     {{ tree }}
     {% if has_links %}
       <h1 id="book-label-{{ book_id}}" class="isu-book-navigation-title h5">{{ 'Navigate this book'|t }}</h1>

--- a/templates/book/book-tree.html.twig
+++ b/templates/book/book-tree.html.twig
@@ -30,7 +30,7 @@
   {% import _self as book_tree %}
   {% if items %}
     {% if menu_level == 0 %}
-    <nav role="navigation">
+    <nav>
       <h1 class="isu-book-tree-title h5">{{ 'Pages in this section'|t }}</h1>
       <ul{{ attributes }}>
     {% else %}

--- a/templates/content-edit/filter-caption.html.twig
+++ b/templates/content-edit/filter-caption.html.twig
@@ -19,7 +19,7 @@
 
 {% set figid = random() %}
 
-<figure role="group" class="caption caption-{{ tag }}{%- if classes %} {{ classes }}{%- endif %}" aria-labelledby="{{ figid }}">
+<figure class="caption caption-{{ tag }}{%- if classes %} {{ classes }}{%- endif %}" aria-labelledby="{{ figid }}">
   {{ node }}
   <figcaption id="{{ figid }}">{{ caption }}</figcaption>
 </figure>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -69,7 +69,7 @@
 {# menu-navbar.html.twig contains the main menu #}
 {% include '@iastate_theme/parts/menu-navbar.html.twig' %}
 
-<main class="isu-main" role="main">
+<main class="isu-main">
 
   <a id="main-content" tabindex="-1"></a>
 
@@ -94,7 +94,7 @@
 
       {% if page.sidebar_first|render %}
         <div class="isu-page-column isu-sidebar isu-sidebar-first {{sidebar_classes}}">
-          <aside role="complementary">
+          <aside>
             {{ page.sidebar_first }}
           </aside>
         </div>
@@ -108,7 +108,7 @@
 
       {% if page.sidebar_second|render %}
         <div class="isu-page-column isu-sidebar isu-sidebar-second {{sidebar_classes}}">
-          <aside role="complementary">
+          <aside>
             {{ page.sidebar_second }}
           </aside>
         </div>

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -8,7 +8,7 @@
  */
 #}
 {% if breadcrumb %}
-  <nav role="navigation" aria-label="{{ 'Breadcrumb'|t }}">
+  <nav aria-label="{{ 'Breadcrumb'|t }}">
     <ol class="breadcrumb isu-breadcrumb">
     {% for item in breadcrumb %}
       <li class="breadcrumb-item">

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -30,7 +30,7 @@
  */
 #}
 {% if items %}
-  <nav role="navigation" aria-label="{{ 'Pagination'|t }}">
+  <nav aria-label="{{ 'Pagination'|t }}">
     <ul class="pagination isu-pagination">
       {# Print first item if we are not on the first page. #}
       {% if items.first %}

--- a/templates/navigation/views-mini-pager.html.twig
+++ b/templates/navigation/views-mini-pager.html.twig
@@ -10,7 +10,7 @@
  */
 #}
 {% if items.previous or items.next %}
-  <nav role="navigation" aria-label="{{ 'Pagination'|t }}">
+  <nav aria-label="{{ 'Pagination'|t }}">
     <ul class="js-pager__items pagination isu-pagination pagination-sm">
       {% if items.previous %}
         <li class="page-item">

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -13,7 +13,7 @@
  */
 #}
 
-<footer role="contentinfo" class="isu-footer" aria-label="Footer">
+<footer class="isu-footer" aria-label="Footer">
   <div class="container">
     <div class="row">
 

--- a/templates/parts/site-navbar.html.twig
+++ b/templates/parts/site-navbar.html.twig
@@ -18,7 +18,7 @@
   ] 
 %}
 
-<header{{ attributes.addClass(site_navbar_classes) }} role="banner" aria-label="Site header">
+<header{{ attributes.addClass(site_navbar_classes) }} aria-label="Site header">
   <div class="container">
     <div class="row isu-row-site-navbar">
 

--- a/templates/parts/submitted-by.html.twig
+++ b/templates/parts/submitted-by.html.twig
@@ -6,7 +6,7 @@
  */
 #}
 
-<footer class="isu-submitted-by_card d-flex align-items-center mb-3" role="contentinfo">
+<footer class="isu-submitted-by_card d-flex align-items-center mb-3">
   {{ author_picture }}
   <div>
     <span class="isu-submitted-by_name">{% trans %}Submitted by {{ author_name }} </span>


### PR DESCRIPTION
From the ticket: 

_A WAI-ARIA attribute that has the exact same features as the HTML element it has been applied to has been used. The WAI-ARIA attribute is redundant since is doesn't provide the user with any additional information._

_For landmarks it has previously been a recommendation to use HTML5 and WAI-ARIA landmark roles together (e.g. WAI-ARIA role="navigation" on HTML5 'nav' elements) to maximize support, but with the widespread adoption of HTML5 this is no longer needed._

Here are the landmarks/roles I found and corrected:

1. header/banner
2. nav/navigation
3. aside/complementary
4. footer/content-info
5. figure/group
6. main/main

To test, I recommend double-checking my changes to ensure there are no typos. 