### PR TITLE
D8ISUTHEME-137 Make date field labels bold

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -938,7 +938,8 @@ details {
 .isu-form-type_tel label,
 .isu-form-type_url label,
 .isu-form-type_date label,
-.isu-form-type_number label {
+.isu-form-type_number label,
+.field--type-datetime label {
   /* .filter-wrapper via Drupal 8 */
   font-weight: 700;
 }

--- a/templates/forms/datetime-wrapper.html.twig
+++ b/templates/forms/datetime-wrapper.html.twig
@@ -20,7 +20,7 @@
   ]
 %}
 {% if title %}
-  <p{{ title_attributes.addClass(title_classes) }}>{{ title }}</p>
+  <label{{ title_attributes.addClass(title_classes) }}>{{ title }}</label>
 {% endif %}
 {{ content }}
 {% if errors %}


### PR DESCRIPTION
This branch does two things for a Date field
1. Uses the `label` element for the label
2. Makes the label bold.

To test:
Add a date field to a content type. Make sure not to use Date and Time.