### PR TITLE
D8ISUTHEME-128 Remove node-type class from pages that aren't nodes

### DIFF
--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -12,6 +12,9 @@ function iastate_theme_preprocess_html(&$variables) {
   if ($node instanceof NodeInterface) {
     $variables['attributes']['class'][] = 'node-id_' . $node->id();
   }
+  if (isset($variables['node_type'])) {
+    $variables['attributes']['class'][] = 'node-type_' . $variables['node_type'];
+  }
 }
 
 /*

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -35,7 +35,6 @@
   {%
     set body_classes = [
       logged_in ? 'logged-in',
-      'node-type_' ~ node_type|clean_class,
       is_node_edit == 'edit' ? 'node-form node-form_' ~ 'edit',
       is_node_add == 'add' ? 'node-form node-form_' ~ 'add',
       is_node_delete == 'delete' ? 'node-form node-form_' ~ 'delete',


### PR DESCRIPTION
https://isubit.atlassian.net/browse/D8ISUTHEME-128

The original but was that `node-type_` classes appeared on the `body` of pages that aren't nodes (like our temporary landing page or Views). 

This pull requests fixes that by moving the way the class is added from the template to a preprocess function that first checks if there even is a node type set. 

To test:
1. Make a D8 site with a couple nodes of different types and a view.
2. Confirm there is a `node-type_` class for nodes and that the machine name is filled in.
3. Confirm there is _not_ a `node-type_` class for non-nodes. 