### PR TITLE
D8ISUTHEME-141 Fix block title wrapping on views exposed filters set …

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1561,6 +1561,9 @@ blockquote.isu-pull-quote {
   flex-wrap: wrap;
   margin-bottom: 1rem;
 }
+.views-exposed-form .isu-block-title {
+  width: 100%;
+}
 .views-exposed-form .isu-form-group {
   margin-right: 1rem;
 }


### PR DESCRIPTION
…to appear as a block

When a Views exposed filter is set to appear as a block, the block title and filter form are mushed onto one line. This PR fixes the CSS so the block's title is stacked above the form. https://isubit.atlassian.net/browse/D8ISUTHEME-141

To test...
I set up a duplicate People View to have the Department filter exposed in a block, then placed the block with the block title set to show. Confirm the block title appears as it should, fill width at the top of the block.