### PR TITLE
D8ISUTHEME-142 Override Bootstrap4's user-select on .btn

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -93,6 +93,12 @@ a.nav-link { /* Some links to not need underlines. */
 .page-link:hover { /* Overrides bootstrap.min.css */
   color: #006BA6; /* ISU brand standard */
 }
+.btn {
+  -webkit-user-select: initial;
+  -moz-user-select: initial;
+  -ms-user-select: initial;
+  user-select: initial;
+}
 button.btn {
   cursor: pointer;
 }


### PR DESCRIPTION
https://isubit.atlassian.net/browse/D8ISUTHEME-142

Try in a couple of browsers, including Firefox where the issue was.

To test:
1. Create a page
2. In the WYSIWYG add a link and make it a button.
3. Confirm you click inside the button text to place your cursor in it.
4. Confirm you can use the arrow keys to move the cursor into the button text.