### PR TITLE
D8ISUTHEME-147 Make footer block titles smaller

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1302,6 +1302,15 @@ a.tabledrag-handle .handle {
   padding: 1rem 0;
   background: #dddddd;
 }
+.isu-footer_contact-title,
+.isu-footer .isu-block-title {
+  margin-bottom: 0.5rem;
+  padding-bottom: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  font-weight: 700;
+  border-bottom: 0;
+}
 
 /* --- ## ASSOCIATES MENU --- */
 /*

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -111,7 +111,7 @@
           <div class="mb-3">
 
             {% if iastate_contact_title %}
-              <h2 class="isu-footer_contact-title h5" id="footercontact">
+              <h2 class="isu-footer_contact-title" id="footercontact">
                 {{ iastate_contact_title|nl2br }}
               </h2>
             {% else %}


### PR DESCRIPTION
https://isubit.atlassian.net/browse/D8ISUTHEME-147

This pull requests makes block titles in the footer smaller, bold, and dark grey. It applies to the default footer contact block, and `.isu-block-title` which is the class applied to Sites+ block types (Text Card, Link Card, etc). 

**To test**
1. Enter some contact information 
2. Create and place a Text Card, Link Card, or other Sites Card in any Footer region and set the block title to show.
3. Confirm the titles match the design in the ticket.