### PR TITLE
D8ISUTHEME-149 Adjust colors for contrast in sign-off footer region

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1311,6 +1311,18 @@ a.tabledrag-handle .handle {
   font-weight: 700;
   border-bottom: 0;
 }
+.isu-region_sign-off {
+  color: #616161;
+}
+.isu-region_sign-off a:not(.btn) {
+  color: #c70000;
+}
+.isu-region_sign-off a:not(.btn):hover {
+  color: #00679E;
+}
+.isu-region_sign-off blockquote {
+  border-color: #aaaaaa;
+}
 
 /* --- ## ASSOCIATES MENU --- */
 /*


### PR DESCRIPTION
The background of the sign-off theme region in the footer is slightly darker than the actual footer, so the color contrast of text and other content elements was just a little too low. This PR boosts the contrast.

To test, I recommend creating a Text Card with text, links, buttons, quotes, etc and placing it in the footer. Then test the color contrast for legibility.