### PR TITLE
D8ISUTHEME-150 Add support for slogan

### DIFF
--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -54,6 +54,10 @@
       </h1>
       
     {% endif %}
+
+    {% if site_slogan %}
+      <div class="isu-slogan">{{ site_slogan }}</div>
+    {% endif %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
Drupal core has a field in basic site settings called "slogan". Our base theme should support it.

Build a plain D8 site and add this theme. Go to Configuration > Basic Site Settings and add a slogan.

The slogan should appear below the site name.

Note: Our subtheme has its own version of this template, so that will be a PR to the bitbucket repo.