### PR TITLE
D8ISUTHEME-154 Allow site logo to be optional.

### DIFF
--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -31,7 +31,9 @@
 
 {% block content %}
   <div class="isu-wordmark">
-    <img class="isu-wordmark-logo" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+    {% if site_logo %}
+      <img class="isu-wordmark-logo" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+    {% endif %}
 
     {% if iastate_unit_name %}
 


### PR DESCRIPTION
The theme settings UI allows you to uncheck "Use the logo supplied by the theme" and then not add any other options. Right now, if you do this and choose to have no logo, a broken image tag shows up. This pull request just removes the image tag when there is no logo.

1. Create a plain D8/D9 site
2. admin/appearance/settings/iastate8_theme
3. Test all three logo options:
  a. Use the logo supplied by the theme
  b. Upload a new logo
  c. No logo
4. Confirm the logo appears or doesn't as expected, no empty or broken image tags.