### PR TITLE
D8ISUTHEME-156 Remove incorrect aria-expanded attribute from ISU Navbar

### DIFF
--- a/css/isu-navbar.css
+++ b/css/isu-navbar.css
@@ -121,7 +121,7 @@
 /* Dropdown menus
 /* -------------------------------------- */
 
-.isu-navbar_dropdown[aria-expanded='false'] .isu-navbar_dropdown-menu {
+.isu-navbar_dropdown[data-isu-navbar-expanded='false'] .isu-navbar_dropdown-menu {
   display: none;
 }
 @media (min-width: 992px) {

--- a/js/isu-navbar.js
+++ b/js/isu-navbar.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
         // Add class for styling
         dropdownToggle.addClass('has-focus');
         // Open menu
-        dropdownToggle.parents('.isu-navbar_dropdown').attr('aria-expanded', 'true');
+        dropdownToggle.parents('.isu-navbar_dropdown').attr('data-isu-navbar-expanded', 'true');
         // Change focus to first link in the dropdown
         $(':focus').next().find('li:first-of-type a').focus();
       }
@@ -76,7 +76,7 @@ $(document).ready(function() {
     var dropdownMenuItem = $(this);
       if (event.keyCode === 38) { // up
         // Close the dropdown
-        dropdownMenuItem.closest('.isu-navbar_dropdown').attr('aria-expanded', 'false');
+        dropdownMenuItem.closest('.isu-navbar_dropdown').attr('data-isu-navbar-expanded', 'false');
         // Refocus on the parent link
         dropdownMenuItem.closest('.isu-navbar_dropdown').find('a').focus();
       }
@@ -87,7 +87,7 @@ $(document).ready(function() {
     var dropdownMenuItem = $(this);
       if (event.keyCode === 38) { // up
         // Close the dropdown
-        dropdownMenuItem.closest('.isu-navbar_dropdown').attr('aria-expanded', 'false');
+        dropdownMenuItem.closest('.isu-navbar_dropdown').attr('data-isu-navbar-expanded', 'false');
         // Refocus on the parent link.
         dropdownMenuItem.closest('.isu-navbar_dropdown').find('a').focus();
       }
@@ -101,7 +101,7 @@ $(document).ready(function() {
         // If the dropdown nor its children don't not have focus...
         if ( dropdownMenu.siblings('a:focus').length === 0) {
           // Close the menu
-          dropdownMenu.parents('.isu-navbar_dropdown').attr('aria-expanded', 'false');
+          dropdownMenu.parents('.isu-navbar_dropdown').attr('data-isu-navbar-expanded', 'false');
           // And remove styling class
           dropdownMenu.parents('.isu-navbar_dropdown').removeClass('has-focus');
         }

--- a/templates/parts/isu-navbar.html.twig
+++ b/templates/parts/isu-navbar.html.twig
@@ -16,7 +16,7 @@
 <nav class="isu-navbar" aria-label="Iowa State University quicklinks">
   <ul class="isu-navbar_container" id="isu-navbar">
     <li><a href="https://www.iastate.edu" title="Iowa State University Home Page">iastate.edu</a></li>
-    <li class="isu-navbar_dropdown_alpha isu-navbar_dropdown" aria-expanded="false">
+    <li class="isu-navbar_dropdown_alpha isu-navbar_dropdown" data-isu-navbar-expanded="false">
       <a href="https://www.iastate.edu/index/A" class="isu-navbar_dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">Index</a>
       <ul class="isu-navbar_dropdown-menu isu-navbar_alpha">
         <li><a href="https://www.iastate.edu/index/A/">A</a></li>
@@ -51,7 +51,7 @@
     <li><a href="https://info.iastate.edu/">Directory</a></li>
     <li><a href="https://www.fpm.iastate.edu/maps/">Maps</a></li>
     <li><a href="https://web.iastate.edu/safety/">Safety</a></li>
-    <li class="isu-navbar_dropdown_signons isu-navbar_dropdown" aria-expanded="false">
+    <li class="isu-navbar_dropdown_signons isu-navbar_dropdown" data-isu-navbar-expanded="false">
       <a href="https://web.iastate.edu/signons" class="isu-navbar_dropdown-toggle" role="button" aria-haspopup="true" aria-expanded="false">Sign Ons</a>
       <ul class="isu-navbar_dropdown-menu isu-navbar_signons">
         <li><a href="https://accessplus.iastate.edu/">AccessPlus</a></li>


### PR DESCRIPTION
A SiteImprove scan detected an incorrectly applied `aria-expanded` attribute on an unsupported element (`li`). It turns out, the ARIA attribute was not needed in those positions and were being used for the js interaction. This pull request, replaces the ARIA attribute with a `data-` attribute instead.

See the ticket for more details: https://isubit.atlassian.net/browse/D8ISUTHEME-156

To test:
1. Create a D8/D9 site
2. Ensure the black ISU Navbar functions with both mouse and keyboard interaction.
3. Check code for accessibility.