### PR TITLE
D8ISUTHEME-158 Logo link theme setting

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -4,6 +4,7 @@ iastate_copyright_hidden: 0
 features:
   favicon: true
 iastate_logo_alt: ''
+iastate_logo_url: ''
 iastate_unit_name: ''
 iastate_unit_url: ''
 iastate_footer_logo_path: themes/contrib/iastate_theme/isu-stacked.svg

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -167,7 +167,7 @@ function iastate_theme_preprocess(&$variables, $hook) {
 
 function iastate_theme_preprocess_block(&$variables) {
   $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
-
+  $variables['iastate_logo_url'] = theme_get_setting('iastate_logo_url');
 }
 
 /*

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -31,8 +31,16 @@
 
 {% block content %}
   <div class="isu-wordmark">
+    {% if iastate_logo_url %}
+      <a href="{{ iastate_logo_url }}">
+    {% endif %}
+
     {% if site_logo %}
       <img class="isu-wordmark-logo" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+    {% endif %}
+    
+    {% if iastate_logo_url %}
+      </a>
     {% endif %}
 
     {% if iastate_unit_name %}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -23,12 +23,28 @@
  */
 function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
 
+  // Logo settings
+  $form['logo']['logo_settings'] = array(
+    '#type'         => 'details',
+    '#title'        => t('Custom logo Settings'),
+    '#weight' => 1,
+    '#open' => FALSE,
+  );
+
   // Logo alt text
-  $form['logo']['iastate_logo_alt'] = array(
+  $form['logo']['logo_settings']['iastate_logo_alt'] = array(
     '#type'   => 'textfield',
     '#title'  => t('Logo alt text'),
     '#default_value'  => theme_get_setting('iastate_logo_alt'),
-    '#description' => t('If left blank the alt text will be Iowa State University logo'),
+    '#description' => t('If left blank the alt text will be "Iowa State University logo".'),
+  );
+
+  // Logo custom url
+  $form['logo']['logo_settings']['iastate_logo_url'] = array(
+    '#type'   => 'textfield',
+    '#title'  => t('Logo link'),
+    '#description' => t('By default the logo is not linked. Use this field to add a link.'),
+    '#default_value'  => theme_get_setting('iastate_logo_url'),
   );
 
   // Create a section for ISU theme settings
@@ -93,7 +109,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Contact Info'),
     '#description'  => t('Contact information is displayed in the footer'),
-    '#weight'       => -998,
+    '#weight'       => 10,
     '#open'         => TRUE,
     );
 
@@ -140,7 +156,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Associates'),
     '#description'  => t('Organization associates are displayed as a list in the footer.'),
-    '#weight' => -800,
+    '#weight' => 11,
     '#open' => TRUE,
   );
   
@@ -226,7 +242,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Social Media Links'),
     '#description'  => t('A list of social media links are displayed in the footer.'),
-    '#weight' => -800,
+    '#weight' => 11,
     '#open' => TRUE,
   );
   


### PR DESCRIPTION
There is now an option to make the site logo a link.

1. Create a plain D8 site and make this base theme the default theme.
2. Go to Appearance > Settings for this theme.
3. Find the new logo link setting in the logo section.
4. Give it a try. 