### PR TITLE
D8ISUTHEME-157 Header and footer logo dimensions

### DIFF
--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -5,7 +5,7 @@ features:
   favicon: true
 iastate_logo_alt: ''
 logo:
-  use_default: ''
+  use_default: 1
   path: ''
 iastate_logo_width: ''
 iastate_logo_height: ''
@@ -14,6 +14,8 @@ iastate_unit_url: ''
 iastate_footer_logo_path: themes/contrib/iastate_theme/isu-stacked.svg
 iastate_footer_logo_url: 'https://www.iastate.edu/'
 iastate_footer_logo_alt: ''
+iastate_footer_logo_width: '180'
+iastate_footer_logo_height: '58'
 iastate_contact_address: "2221 Wanda Daley Dr\n2nd Floor ASB\nAmes, IA 50011"
 iastate_contact_email: 'theme@iastate.edu'
 iastate_contact_phone: '515-294-6654'

--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -4,7 +4,7 @@ iastate_copyright_hidden: 0
 features:
   favicon: true
 logo:
-  use_default: 1
+  use_default: true
   path: ''
 iastate_logo_alt: ''
 iastate_logo_width: ''

--- a/config/install/iastate_theme.settings.yml
+++ b/config/install/iastate_theme.settings.yml
@@ -4,6 +4,11 @@ iastate_copyright_hidden: 0
 features:
   favicon: true
 iastate_logo_alt: ''
+logo:
+  use_default: ''
+  path: ''
+iastate_logo_width: ''
+iastate_logo_height: ''
 iastate_unit_name: ''
 iastate_unit_url: ''
 iastate_footer_logo_path: themes/contrib/iastate_theme/isu-stacked.svg

--- a/css/base.css
+++ b/css/base.css
@@ -260,7 +260,7 @@ caption {
 /* ## IMAGES
 /* --------------------------------------  */
 
-img:not(.isu-wordmark-logo_custom) { /* See theme.css */
+img:not(.isu-wordmark-logo_default):not(.isu-wordmark-logo_custom):not(.isu-footer-logo) { /* See theme.css */
   max-width: 100%;
   height: auto;
 }

--- a/css/base.css
+++ b/css/base.css
@@ -260,7 +260,7 @@ caption {
 /* ## IMAGES
 /* --------------------------------------  */
 
-img {
+img:not(.isu-wordmark-logo_custom) { /* See theme.css */
   max-width: 100%;
   height: auto;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -176,7 +176,7 @@ body,
   }
 .isu-wordmark-logo_default {
   width: 100%;
-  max-width: 250px;
+  max-width: 250px ;
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -1306,9 +1306,9 @@ a.tabledrag-handle .handle {
   color: #676767;
   background: #f3f3f3;
 }
-.isu-footer-logo {
-  width: 100%;
-  max-width: 180px;
+.isu-footer-logo { 
+  max-width:  100%;
+  height: auto;
 }
 .isu-sign-off_wrapper {
   margin-bottom: -2rem;

--- a/css/theme.css
+++ b/css/theme.css
@@ -174,9 +174,13 @@ body,
   .isu-wordmark a:focus {
     color: #ffffff;
   }
-.isu-wordmark-logo {
+.isu-wordmark-logo_default {
   width: 100%;
   max-width: 250px;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.isu-wordmark-logo_custom {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
@@ -200,9 +204,18 @@ body,
   border-top: 1px solid rgba(255, 255, 255, 0.5);
 }
 
+/* Medium */
+@media (max-width: 991px) {
+  .isu-wordmark-logo_custom {
+    width: 100%;
+    max-width: 250px;
+    height: auto;
+  }
+}
+
 /* Large */
 @media screen and (min-width: 992px) {
-  .isu-wordmark-logo {
+  .isu-wordmark-logo_default {
     width: 100%;
     max-width: 400px;
     margin-top: 0;

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -188,6 +188,8 @@ function iastate_theme_preprocess_page(&$variables) {
   $variables['iastate_footer_logo_path'] = theme_get_setting('iastate_footer_logo_path');
   $variables['iastate_footer_logo_url'] = theme_get_setting('iastate_footer_logo_url');
   $variables['iastate_footer_logo_alt'] = theme_get_setting('iastate_footer_logo_alt');
+  $variables['iastate_footer_logo_width'] = theme_get_setting('iastate_footer_logo_width');
+  $variables['iastate_footer_logo_height'] = theme_get_setting('iastate_footer_logo_height');
 
   $variables['iastate_contact_title'] = theme_get_setting('iastate_contact_title');
   $variables['iastate_contact_address'] = theme_get_setting('iastate_contact_address');

--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -167,7 +167,10 @@ function iastate_theme_preprocess(&$variables, $hook) {
 
 function iastate_theme_preprocess_block(&$variables) {
   $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
-
+  $variables['iastate_logo_width'] = theme_get_setting('iastate_logo_width');
+  $variables['iastate_logo_height'] = theme_get_setting('iastate_logo_height');
+  $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
+  $variables['is_default_logo'] = \Drupal::config('iastate_theme.settings')->get('logo.use_default');
 }
 
 /*

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -30,9 +30,15 @@
 {% extends "block.html.twig" %}
 
 {% block content %}
+
   <div class="isu-wordmark">
+
     {% if site_logo %}
-      <img class="isu-wordmark-logo" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+      {% if is_default_logo %}
+        <img class="isu-wordmark-logo isu-wordmark-logo_default" width="400" height="30" src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+      {% else %}
+        <img class="isu-wordmark-logo isu-wordmark-logo_custom" {% if iastate_logo_width %}width="{{ iastate_logo_width }}"{% endif %} {% if iastate_logo_height %} height="{{ iastate_logo_height }}"{% endif %} src="{{ site_logo }}" {% if iastate_logo_alt %} alt="{{ iastate_logo_alt }}" {% else %} alt="Iowa State University logo"{% endif %}>
+      {% endif %}
     {% endif %}
 
     {% if iastate_unit_name %}

--- a/templates/parts/footer.html.twig
+++ b/templates/parts/footer.html.twig
@@ -24,7 +24,7 @@
             {% if iastate_footer_logo_url %}
               <a href="{{ iastate_footer_logo_url }}">
             {% endif %}
-                <img class="isu-footer-logo" src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" {% if iastate_footer_logo_alt %} alt="{{ iastate_footer_logo_alt }}" {% else %} alt="Iowa State University logo" {% endif %}>
+                <img class="isu-footer-logo" {% if iastate_footer_logo_width %} width="{{iastate_footer_logo_width }}"{% else %}width="180"{% endif %} {% if iastate_footer_logo_height %} height="{{ iastate_footer_logo_height }}"{% else %}height="58"{% endif %} src="{{ base_path }}{{ iastate_footer_logo_path }}" class="wordmark-isu" {% if iastate_footer_logo_alt %} alt="{{ iastate_footer_logo_alt }}" {% else %} alt="Iowa State University logo" {% endif %}>
             {% if iastate_footer_logo_url %}
               </a>
             {% endif %}

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -378,4 +378,27 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#default_value'  => theme_get_setting('iastate_footer_logo_alt'),
     '#description' => t('If left blank the alt text will be Iowa State University logo'),
   );
+
+  // Footer logo dimensions description
+    $form['iastate_footer_logo']['footer_logo_dimensions_description'] = array(
+    '#type' => 'item',
+    '#title' => t('Logo dimensions'),
+    '#markup' => t('Set an explicit width and height for the footer logo.'),
+  );
+
+  // Footer logo width
+  $form['iastate_footer_logo']['iastate_footer_logo_width'] = array(
+    '#type'   => 'number',
+    '#title'  => t('Footer logo width in pixels'),
+    '#default_value'  => theme_get_setting('iastate_footer_logo_width'),
+    '#description' => t('Default is 180.'),
+  );
+
+  // Footer logo height
+  $form['iastate_footer_logo']['iastate_footer_logo_height'] = array(
+    '#type'   => 'number',
+    '#title'  => t('Footer logo height in pixels'),
+    '#default_value'  => theme_get_setting('iastate_footer_logo_height'),
+    '#description' => t('Default is 58.'),
+  );
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -23,12 +23,41 @@
  */
 function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
 
+  // Logo settings
+  $form['logo']['logo_settings'] = array(
+    '#type'         => 'details',
+    '#title'        => t('Custom logo Settings'),
+    '#weight' => 1,
+    '#open' => FALSE,
+  );
+
   // Logo alt text
-  $form['logo']['iastate_logo_alt'] = array(
+  $form['logo']['logo_settings']['iastate_logo_alt'] = array(
     '#type'   => 'textfield',
     '#title'  => t('Logo alt text'),
     '#default_value'  => theme_get_setting('iastate_logo_alt'),
     '#description' => t('If left blank the alt text will be Iowa State University logo'),
+  );
+
+  // Logo dimensions description
+    $form['logo']['logo_settings']['logo_dimensions_description'] = array(
+    '#type' => 'item',
+    '#title' => t('Logo dimensions'),
+    '#markup' => t('If you are using a custom logo, set an explicit width and height to improve page load time.'),
+  );
+
+  // Logo width
+  $form['logo']['logo_settings']['iastate_logo_width'] = array(
+    '#type'   => 'number',
+    '#title'  => t('Logo width in pixels'),
+    '#default_value'  => theme_get_setting('iastate_logo_width'),
+  );
+
+  // Logo height
+  $form['logo']['logo_settings']['iastate_logo_height'] = array(
+    '#type'   => 'number',
+    '#title'  => t('Logo height in pixels'),
+    '#default_value'  => theme_get_setting('iastate_logo_height'),
   );
 
   // Create a section for ISU theme settings
@@ -93,7 +122,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Contact Info'),
     '#description'  => t('Contact information is displayed in the footer'),
-    '#weight'       => -998,
+    '#weight'       => 10,
     '#open'         => TRUE,
     );
 
@@ -140,7 +169,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Associates'),
     '#description'  => t('Organization associates are displayed as a list in the footer.'),
-    '#weight' => -800,
+    '#weight' => 11,
     '#open' => TRUE,
   );
   
@@ -226,7 +255,7 @@ function iastate_theme_form_system_theme_settings_alter(&$form, &$form_state) {
     '#type'         => 'details',
     '#title'        => t('Social Media Links'),
     '#description'  => t('A list of social media links are displayed in the footer.'),
-    '#weight' => -800,
+    '#weight' => 11,
     '#open' => TRUE,
   );
   


### PR DESCRIPTION
Google's PageSpeed Insights suggests that images have an explicit width and height. The CMS handles this most of the time, but our theme logos need that set up. 

This pull request adds theme settings for the logo dimensions for both the header and footer logo.

- For both the header logo and footer logo, the default ones that are always there should just work. The HTML should have the correct explicit dimensions and there is no need to change the dimensions in theme settings.
- But if custom logos are going to be used, the dimensions need to be filled out.
- On narrow screens, the logos will become responsive regardless of the explicit dimensions.
- (In general, those using custom logos should upload logo images that are already resized.)

To test
1. Create a plain D8 site, add this theme, and set it as default.
2. Observe the header and footer logo. Confirm they are the right size and are responsive to narrowing screens.
3. Inspect the HTML. Confirm the header and footer logo have explicit dimensions set in the HTML.
4. Add a custom header logo and enter the correct dimensions. Confirm the HTML has the right dimensions.
5. Confirm the custom header logo appears the right size and is responsive on narrowing screens.
6. Go through the same steps for the footer logo. 

