### PR TITLE
D8ISUTHEME-163 Shorten search toggle label to just Search

### DIFF
--- a/templates/parts/site-navbar.html.twig
+++ b/templates/parts/site-navbar.html.twig
@@ -33,7 +33,9 @@
 
       <button class="isu-search_toggler" id="isu-search_toggler">
         <span class="fa fa-search isu-search_toggler-icon" aria-hidden="true"></span>
-        <span class="isu-search_toggler-label">Open search bar</span>
+        <span class="isu-search_toggler-label">
+            <span class="sr-only">Open</span> Search <span class="sr-only">Bar</span>
+          </span>
       </button> 
 
       <div class="col-lg isu-col-header-second isu-col-header-second_has-search">


### PR DESCRIPTION
Right now, the entire label for the mobile search button/toggle is being shown and it's not necessary. "Open Search Bar".

This pull request hides "Open" and "Bar" to all but screenreaders, making the label say "Search". 

**To test**
1. `newd8plain.sh D8ISUTHEME163`
2. Add this branch of the base theme and install and set default.
3. Search is automatically on.
4. Narrow the screen and confirm the word Search is below the magnifying glass icon.
5. Confirm it still works.  