### PR TITLE
D8ISUTHEME-164 Adjust header padding

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -83,7 +83,7 @@ body,
  */
 
 .isu-site-navbar {
-  padding: 0;
+  padding: 0.75rem 0;
   background-color: #cc0000;
   border-bottom: 9px solid #f1be48;
 }
@@ -177,11 +177,9 @@ body,
 .isu-wordmark-logo_default {
   width: 100%;
   max-width: 250px ;
-  margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
 .isu-wordmark-logo_custom {
-  margin-top: 0.5rem;
   margin-bottom: 0.5rem;
 }
 .isu-wordmark-unit,


### PR DESCRIPTION
Right now on narrow breakpoints, the site name is too close to the bottom of the red site header. This PR adjusts the padding on header elements for nicer spacing. 

**To test**

1. Create a D9 site with this branch of the base theme.
2. Narrow the screen and confirm that there is always sufficient padding between header elements and the bottom of the red header. 
3. Test with combinations of all wordmark elements, with and without: default logo, custom logo, long site name, slogan, and unit.