### PR TITLE
D8ISUTHEME-165 Move responsive image CSS rule to avoid issues in CKEditor

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -260,6 +260,10 @@ caption {
 /* ## IMAGES
 /* --------------------------------------  */
 
+img { 
+  max-width: 100%;
+  height: auto;
+}
 table img {
   max-width: none; /* Prevents images from shrinking in tables */
 }

--- a/css/base.css
+++ b/css/base.css
@@ -260,10 +260,6 @@ caption {
 /* ## IMAGES
 /* --------------------------------------  */
 
-img:not(.isu-wordmark-logo_default):not(.isu-wordmark-logo_custom):not(.isu-footer-logo) { /* See theme.css */
-  max-width: 100%;
-  height: auto;
-}
 table img {
   max-width: none; /* Prevents images from shrinking in tables */
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1479,6 +1479,11 @@ blockquote.isu-pull-quote {
 
 /* --- ## Images --- */
 
+img:not(.isu-wordmark-logo_default):not(.isu-wordmark-logo_custom):not(.isu-footer-logo) {
+  max-width: 100%;
+  height: auto;
+}
+
 .isu-body img.align-left {
   margin: 1rem 1rem 1rem 0;
 }


### PR DESCRIPTION
Context: https://isubit.atlassian.net/browse/D8ISUTHEME-165 Basically, the image preview for embedded videos in CKEditor was secretly and silently too tall, invisibly covering up content that came after, preventing clicking in it.

To test
1. Create a site with this branch of the base theme
2. Embed a video in a Page and make sure you can add/edit text before and after the video
3. Upload an image to another page that's waaaay too wide, like more than 2000px wide.  Here's one: (http://placehold.it/2000x500). Confirm it scales to fit the editor.
4. Publish that page. Confirm it scales to fit the page.
4. Test the logo image dimensions to make sure they still function.