### PR TITLE
D8ISUTHEME-175 Stop images in tables from squishing

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -265,7 +265,7 @@ img {
   height: auto;
 }
 table img {
-  max-width: none; /* Prevents images from shrinking in tables */
+  max-width: none !important; /* Prevents images from shrinking in tables */
 }
 .caption-img figcaption { /* Class from Drupal. */
   /* Same as table caption. */


### PR DESCRIPTION
Responsive image CSS was causing images in table to squish if content in adjacent cells was big. This fix keeps table images their proper size.

1. To test, create a D9 site with this branch of the base theme. 
2. Make a page with a two column table.
3. In the first column, put an image with dimensions of like, 200 or 300px wide. 
4. In the second column, put in enough text that it would wrap to at least a second line.
5. Publish the page and confirm the image has not been squished.