### PR TITLE
D8ISUTHEME-177 Force table cell widths to 100% on mobile

### DIFF
--- a/css/isu-responsivetables.css
+++ b/css/isu-responsivetables.css
@@ -58,6 +58,10 @@ article table::-webkit-scrollbar-track {
     word-break: break-word;
   }
 
+  .isu-responsive-table td {
+    width: 100% !important; /* In case a width is manually set. */
+  }
+
   /* --- No headers (none) --- */
   .isu-responsive-table.isu-table-none {
     display: table;
@@ -82,8 +86,8 @@ article table::-webkit-scrollbar-track {
     display: none;
   }
   .isu-responsive-table.isu-table-row tr {
-      display: block;
-      border-bottom: 3px solid #bbbbbb;
+    display: block;
+    border-bottom: 3px solid #bbbbbb;
   }
   .isu-responsive-table.isu-table-row tr:first-of-type {
     border-bottom: 0;
@@ -91,7 +95,6 @@ article table::-webkit-scrollbar-track {
   .isu-responsive-table.isu-table-row td {
     display: flex;
     padding: 0;
-    width: 100% !important; /* In case a width is manually set. */
     border-bottom: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
   }

--- a/css/isu-responsivetables.css
+++ b/css/isu-responsivetables.css
@@ -67,9 +67,9 @@ article table::-webkit-scrollbar-track {
     border-bottom: 3px solid #bbbbbb;
   }
   .isu-responsive-table.isu-table-none td {
-      border-bottom: 1px solid #dddddd;
-      border-right: 1px solid #dddddd;
-      display: block;
+    border-bottom: 1px solid #dddddd;
+    border-right: 1px solid #dddddd;
+    display: block;
   }
   .isu-responsive-table.isu-table-none td:last-of-type {
     border-bottom: none;
@@ -91,6 +91,7 @@ article table::-webkit-scrollbar-track {
   .isu-responsive-table.isu-table-row td {
     display: flex;
     padding: 0;
+    width: 100% !important; /* In case a width is manually set. */
     border-bottom: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
   }


### PR DESCRIPTION
A recent change in our Sites+ platform includes a patch to allow content editors to resize table columns. This is great, but the inline CSS on table cells messes up alignment when the responsive tables kick in on mobile.

**To test**

1. Create a Sites+ site on the development branch and use this branch of the base theme.
2. Create a page and add a table with multiple columns
3. Resize some of the columns.
4. Narrow the screen until the responsive table kicks in and the table moves to a single column
5. Confirm all the rows are the correct width and not jagged and that everything is still readable.