### PR TITLE
D8ISUTHEME-180 Add front and views classes to body

### DIFF
--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -6,15 +6,26 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Implements template_preprocess_html().
  * 
- * Add node-id_{id} class.
  */
 function iastate_theme_preprocess_html(&$variables) {
+
+  /* Add node-id_ and node-type_ classes to body */
   $node = \Drupal::request()->attributes->get('node');
   if ($node instanceof NodeInterface) {
     $variables['attributes']['class'][] = 'node-id_' . $node->id();
   }
   if (isset($variables['node_type'])) {
     $variables['attributes']['class'][] = 'node-type_' . $variables['node_type'];
+  }
+
+  /* Add views classes to body */
+  $route = \Drupal::routeMatch()->getRouteObject();
+  $view_id = $route->getDefault('view_id');
+  $display_id = $route->getDefault('display_id');
+
+  if ($view_id) {
+    $variables['attributes']['class'][] = 'view_' . $view_id;
+    $variables['attributes']['class'][] = 'view-display_' . $display_id;
   }
 }
 

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -38,6 +38,7 @@
       is_node_edit == 'edit' ? 'node-form node-form_' ~ 'edit',
       is_node_add == 'add' ? 'node-form node-form_' ~ 'add',
       is_node_delete == 'delete' ? 'node-form node-form_' ~ 'delete',
+      is_front ? 'is_front' : 'not_front',
     ]
   %}
   <body{{ attributes.addClass(body_classes) }}>


### PR DESCRIPTION
https://isubit.atlassian.net/browse/D8ISUTHEME-180

Right now there are several useful classes that show up on the body element. This PR adds a couple more.

1. `is_front` or `not_front`
2. `view_{view id}` and `view-display_{view-display}`

To test:

1. Create Sites+ D9 site using this branch for the base theme.
3. Enable some views, create some nodes, set some things to `<front>`.
4. Confirm the correct CSS classes are showing up on the `<body>`. 

For example, if you set the People Directory to front, I'd expect to see:
* `is_front`
* `view_people`
* `view-display_people_directory`
