### PR TITLE
D8ISUTHEME-183 Add block type classes to blocks

### DIFF
--- a/iastate_theme.theme
+++ b/iastate_theme.theme
@@ -171,16 +171,22 @@ function iastate_theme_preprocess(&$variables, $hook) {
 /*
  * Implements theme_preprocess_block().
  *
- * Make theme settings available in block templates
  */
 
 function iastate_theme_preprocess_block(&$variables) {
+  // Make theme settings available in block templates
   $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
   $variables['iastate_logo_width'] = theme_get_setting('iastate_logo_width');
   $variables['iastate_logo_height'] = theme_get_setting('iastate_logo_height');
   $variables['iastate_logo_alt'] = theme_get_setting('iastate_logo_alt');
   $variables['is_default_logo'] = \Drupal::config('iastate_theme.settings')->get('logo.use_default');
   $variables['iastate_logo_url'] = theme_get_setting('iastate_logo_url');
+
+  // Make block type available in block templates
+  if ($variables['elements']['#base_plugin_id'] == 'block_content') {
+    $blockType = strtr($variables['content']['#block_content']->bundle(), '_', '-');
+    $variables['attributes']['class'][] = 'block-type_' . $blockType;
+  }
 }
 
 /*


### PR DESCRIPTION
To test

1. Create a Drupal 9 site with this version of the base theme. (Very okay to make a Sites+ site)
2. If using a Sites+ site, enable Landing Page to get Cards
3. Structure > Blocks > Custom Block Library
4. Create and place different kinds of blocks in theme regions.
5. Create a custom block type and place one in a theme region.
6. Inspect the HTML and confirm that any content blocks have a `block-type_` class. 
7. NOTE: iastate8_cards block types also have their own templates and `isu-` block type classes. This is fine.
8. Confirm the `block-type_` class isn't showing up on, like, view blocks or system blocks.