### PR TITLE
D8ISUTHEME-184 Improve responsive tables

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -228,18 +228,45 @@ button.btn {
 /* --------------------------------------  */
 /* ## TABLES
 /* --------------------------------------  */
-/* Overrides bootstrap.min.css */
 
-.table tbody {
+/* Duplicate bootstrap.min.css just in case .table is 
+ * not automatically applied. 
+ * 
+ * See isu-responsivetables.css for more.
+ */
+
+table {
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+  color: #212529;
+}
+
+tbody {
   border-bottom: 1px solid #cccccc;
 }
-.table thead th,
-.table th {
-  background: #eee;
+
+tr {
+  width: 100%;
 }
-.table thead th {
+
+th {
+  padding: 0.75rem;
+  vertical-align: bottom;
+  background: #eee;
+  border-top: 1px solid #dee2e6;
   border-bottom: 2px solid #cccccc;
 }
+
+td {
+  padding: 0.75rem;
+  vertical-align: top;
+  border-top: 1px solid #dee2e6;
+}
+
+/* Overrides bootstrap.min.css */
 caption {
   caption-side: top;
   padding: 0.5rem 0;
@@ -255,6 +282,8 @@ caption {
   border-right: 1px solid #dddd;
   border-left: 1px solid #ddd;
 }
+
+.isu-view-table { display: table; }
 
 /* --------------------------------------  */
 /* ## IMAGES
@@ -371,7 +400,7 @@ body.cke_editable figure figcaption {
 }
 
 /*
- * Duplicate Bootstrap 4 styles in the ckeditor so table look as 
+ * Duplicate Bootstrap 4 styles in the ckeditor so tables look as 
  * true-to-live as possible.
  */
 

--- a/css/isu-responsivetables.css
+++ b/css/isu-responsivetables.css
@@ -1,34 +1,38 @@
 /**
  * @file
- * CSS for responsive tables. Table styling comes from the
- * Bootstrap 4 table classes, unless where overriden in base.css.
+ * CSS for responsive tables.
  */
 
 /* --------------------------------------  */
 /* ## If javascript is disabled
 /* --------------------------------------  */
 
-article table {
-  display: block; /* Allows overflow-x to scroll */
-  max-width: 100%;
-  overflow: hidden;
-  overflow-x: auto;
+/* If js is disabled, table styling is applied directly to the 
+ * element from base.css, duplicating Bootstrap 4's table styling. 
+ * Tables in Views get their table class from the views-view-table.html.twig.
+ *
+ * Our responsive solution when javascript is disabled is a contained
+ * horizontally scrolling table.
+ */
+
+table { 
+  display: block; /* Allows overflow-x to scroll */ 
 }
-article table tr {
+table tr {
   width: 100%;
 }
-article table::-webkit-scrollbar {
+table::-webkit-scrollbar {
   -webkit-appearance: none;
 }
-article table::-webkit-scrollbar:horizontal {
+table::-webkit-scrollbar:horizontal {
   height: 11px;
 }
-article table::-webkit-scrollbar-thumb {
+table::-webkit-scrollbar-thumb {
   border-radius: 8px;
   border: 2px solid white;
   background-color: rgba(0, 0, 0, 0.5);
 }
-article table::-webkit-scrollbar-track {
+table::-webkit-scrollbar-track {
   background-color: #fff;
   border-radius: 8px;
 }
@@ -72,6 +76,7 @@ article table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-none td {
     border-bottom: 1px solid #dddddd;
+    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
     display: block;
   }
@@ -89,13 +94,15 @@ article table::-webkit-scrollbar-track {
     display: block;
     border-bottom: 3px solid #bbbbbb;
   }
-  .isu-responsive-table.isu-table-row tr:first-of-type {
+  .isu-responsive-table.isu-table-row thead tr,
+  .isu-responsive-table.isu-table-row tbody tr:last-of-type {
     border-bottom: 0;
   }
   .isu-responsive-table.isu-table-row td {
     display: flex;
     padding: 0;
     border-bottom: 1px solid #dddddd;
+    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
   }
   .isu-responsive-table.isu-table-row td:last-of-type {
@@ -134,6 +141,7 @@ article table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-col td {
     border-bottom: 1px solid #dddddd;
+    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
     display: block;
   }
@@ -164,6 +172,9 @@ article table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-both tr:nth-of-type(2) {
     border-top: 1px solid #dddddd;
+  }
+  .isu-responsive-table.isu-table-both tr:last-of-type {
+    border-bottom: 0;
   }
   .isu-responsive-table.isu-table-both td {
     display: flex;

--- a/js/isu-responsivetables.js
+++ b/js/isu-responsivetables.js
@@ -7,8 +7,8 @@
 
 $(document).ready(function() {
   
-  // Find tables in content
-  var table = $('article table');
+  // Find tables in content or make-responsive tables.
+  var table = $('article table, .make-responsive-table table, table.make-responsive-table');
   
 /* 
  * First, check the table structure and assign classes.
@@ -36,7 +36,6 @@ $(document).ready(function() {
   table.addClass('isu-responsive-table table');
 
   // Colspan or Rowspan
-  
   /* Remove extranneous colspan and rowspan */
 
   $('th[colspan="1"]').removeAttr('colspan');
@@ -75,7 +74,7 @@ $(document).ready(function() {
   // Cycle through each row...
   $('.isu-table-row tr').each(function() {
     // And cycle through each td in that row...
-   $(this).find('td').each(function(i) {
+    $(this).find('td').each(function(i) {
       // Find the content of the closest th...    
       var rowHeader = $(this).closest('.isu-table-row').find('tr th')[i].innerHTML;
       // And add it as a span in the td.

--- a/templates/views/views-view-table.html.twig
+++ b/templates/views/views-view-table.html.twig
@@ -35,7 +35,8 @@
     'cols-' ~ header|length,
     responsive ? 'responsive-enabled',
     sticky ? 'sticky-enabled',
-    'table'
+    'table',
+    'isu-view-table'
   ]
 %}
 <table{{ attributes.addClass(table_classes) }}>


### PR DESCRIPTION
This PR does four things:

1. Styles all table elements directly by duplicating Bootstrap 4 styles directly onto `<table>`
2. Creates the `make-responsivle-table` class for making tables in Views and blocks responsive.
3. Cleans up and improves existing table styling.
4. Adds some useful classes on Views tables.

My thought process is here: https://isubit.atlassian.net/browse/D8ISUTHEME-184

**To test**
Create a D9 Sites+ site with this branch of the base theme and make some tables:

Tables in nodes - Make a page or news article (etc) with tables inside. Make tables with no headings, row headings, and column headings. Publish the page. Confirm the tables are styled and responsive. Disable javascript. Confirm the tables are still styled.

Tables in Views - Create or edit a View with a table display. Confirm the table has the `table` and `isu-view-table` class. The table will _not_ be responsive. To make it responsive, edit the View display and add the `make-responsive-table` class under Advance > CSS. This technique will also work for Webforms.

Tables in Text Cards in theme regions - Create a Text Card and place it in a theme region. Confirm it's styled. It won't be responsive without help. Enable the Block Class module and add the `make-responsive-table` class to the Text Card block's configuration.