### PR TITLE
D8ISUTHEME-186 Revert default table styling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -228,45 +228,18 @@ button.btn {
 /* --------------------------------------  */
 /* ## TABLES
 /* --------------------------------------  */
+/* Overrides bootstrap.min.css */
 
-/* Duplicate bootstrap.min.css just in case .table is 
- * not automatically applied. 
- * 
- * See isu-responsivetables.css for more.
- */
-
-table {
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  overflow-x: auto;
-  margin-bottom: 1rem;
-  color: #212529;
-}
-
-tbody {
+.table tbody {
   border-bottom: 1px solid #cccccc;
 }
-
-tr {
-  width: 100%;
-}
-
-th {
-  padding: 0.75rem;
-  vertical-align: bottom;
+.table thead th,
+.table th {
   background: #eee;
-  border-top: 1px solid #dee2e6;
+}
+.table thead th {
   border-bottom: 2px solid #cccccc;
 }
-
-td {
-  padding: 0.75rem;
-  vertical-align: top;
-  border-top: 1px solid #dee2e6;
-}
-
-/* Overrides bootstrap.min.css */
 caption {
   caption-side: top;
   padding: 0.5rem 0;

--- a/css/isu-responsivetables.css
+++ b/css/isu-responsivetables.css
@@ -1,38 +1,34 @@
 /**
  * @file
- * CSS for responsive tables.
+ * CSS for responsive tables. Table styling comes from the
+ * Bootstrap 4 table classes, unless where overriden in base.css.
  */
 
 /* --------------------------------------  */
 /* ## If javascript is disabled
 /* --------------------------------------  */
 
-/* If js is disabled, table styling is applied directly to the 
- * element from base.css, duplicating Bootstrap 4's table styling. 
- * Tables in Views get their table class from the views-view-table.html.twig.
- *
- * Our responsive solution when javascript is disabled is a contained
- * horizontally scrolling table.
- */
-
-table { 
-  display: block; /* Allows overflow-x to scroll */ 
+article table {
+  display: block; /* Allows overflow-x to scroll */
+  max-width: 100%;
+  overflow: hidden;
+  overflow-x: auto;
 }
-table tr {
+article table tr {
   width: 100%;
 }
-table::-webkit-scrollbar {
+article table::-webkit-scrollbar {
   -webkit-appearance: none;
 }
-table::-webkit-scrollbar:horizontal {
+article table::-webkit-scrollbar:horizontal {
   height: 11px;
 }
-table::-webkit-scrollbar-thumb {
+article table::-webkit-scrollbar-thumb {
   border-radius: 8px;
   border: 2px solid white;
   background-color: rgba(0, 0, 0, 0.5);
 }
-table::-webkit-scrollbar-track {
+article table::-webkit-scrollbar-track {
   background-color: #fff;
   border-radius: 8px;
 }
@@ -76,7 +72,6 @@ table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-none td {
     border-bottom: 1px solid #dddddd;
-    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
     display: block;
   }
@@ -94,15 +89,13 @@ table::-webkit-scrollbar-track {
     display: block;
     border-bottom: 3px solid #bbbbbb;
   }
-  .isu-responsive-table.isu-table-row thead tr,
-  .isu-responsive-table.isu-table-row tbody tr:last-of-type {
+  .isu-responsive-table.isu-table-row tr:first-of-type {
     border-bottom: 0;
   }
   .isu-responsive-table.isu-table-row td {
     display: flex;
     padding: 0;
     border-bottom: 1px solid #dddddd;
-    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
   }
   .isu-responsive-table.isu-table-row td:last-of-type {
@@ -141,7 +134,6 @@ table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-col td {
     border-bottom: 1px solid #dddddd;
-    border-left: 1px solid #dddddd;
     border-right: 1px solid #dddddd;
     display: block;
   }
@@ -172,9 +164,6 @@ table::-webkit-scrollbar-track {
   }
   .isu-responsive-table.isu-table-both tr:nth-of-type(2) {
     border-top: 1px solid #dddddd;
-  }
-  .isu-responsive-table.isu-table-both tr:last-of-type {
-    border-bottom: 0;
   }
   .isu-responsive-table.isu-table-both td {
     display: flex;


### PR DESCRIPTION
Context: https://isubit.atlassian.net/browse/D8ISUTHEME-186
More context: https://isubit.atlassian.net/browse/D8ISUTHEME-184

This previous table-change had two parts: a) style all tables and b) be able to make non-responsive table responsive.

It turned out that styling all tables was a much bigger hammer than detected in initial testing and was disrupting things like multi-value fields in node forms, other table-drag UI. 

This PR reverts tables back to working as before, but leaves the modification to the responsivetables javascript file that includes the `make-responsive-table` class which are useful in Views or Webforms as an 'opt -in'.

**To test:**
Create a D9 Sites site with this branch of the base theme.

Platform tables that were inadvertently affected last time, but should not be working normally again
1. Site Settings -> Manage Site Access - confirm the users table is full width as usual
2. Multi-value fields, like Social Media and Websites on People Profiles - should be full width and look correct
3. Edit Menu as a content editor - on the last item, when you opened the edit dropdown, it was clipping off. It should not be clipped any more.

Tables in content should now work as before, without any default styling. Check responsive tables in content still work by making tables with different heading options in a Page.

The `make-responsive-table` class should still be available. Make a table View of some News nodes (or something) and add `make-responsive-table` to the CSS class under advanced. Confirm it makes the table responsive.


